### PR TITLE
feat: add support for target path transforms (`options.transformPath`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A pattern looks like:
 | `flatten` | N | false | Removes all directory references and only copies file names<br><br>If files have the same name, the result is non-deterministic |
 | `ignore` | N | [] | Additional globs to ignore for this pattern |
 | `transform` | N | function(content, path) {<br>&nbsp;&nbsp;return content;<br>} | Function that modifies file contents before writing to webpack |
+| `transformPath` | N | function(targetPath, sourcePath) {<br>&nbsp;&nbsp;return targetPath;<br>} | Function that modifies target file path before writing to webpack |
 | `force` | N | false | Overwrites files already in compilation.assets (usually added by other plugins) |
 
 #### Available options:

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -64,6 +64,10 @@ export default function writeFile(globalRef, pattern, file) {
                 }
             }
 
+            if (typeof pattern.transformPath === 'function') {
+                file.webpackTo = pattern.transformPath(file.webpackTo, file.absoluteFrom);
+            }
+
             if (!copyUnmodified &&
                 written[file.absoluteFrom] && written[file.absoluteFrom][hash]) {
                 info(`skipping '${file.webpackTo}', because it hasn't changed`);

--- a/tests/index.js
+++ b/tests/index.js
@@ -369,6 +369,49 @@ describe('apply function', () => {
             .then(done)
             .catch(done);
         });
+
+        it('can transform target path of every file in glob', (done) => {
+            runEmit({
+                expectedAssetKeys: [
+                    '/some/path/binextension.bin.tst',
+                    '/some/path/file.txt.tst',
+                    '/some/path/directoryfile.txt.tst',
+                    '/some/path/nestedfile.txt.tst',
+                    '/some/path/noextension.tst'
+                ],
+                patterns: [{
+                    from: '**/*',
+                    transformPath: function(targetPath, absoluteFrom) {
+                        expect(absoluteFrom).to.have.string(HELPER_DIR);
+                        return '/some/path/' + path.basename(targetPath) + '.tst';
+                    }
+                }]
+            })
+            .then(done)
+            .catch(done);
+        });
+
+        it('can transform target path of every file in glob after applying template', (done) => {
+            runEmit({
+                expectedAssetKeys: [
+                    'transformed/binextension-d41d8c.bin',
+                    'transformed/file-22af64.txt',
+                    'transformed/directory/directoryfile-22af64.txt',
+                    'transformed/directory/nested/nestedfile-d41d8c.txt',
+                    'transformed/noextension-d41d8c'
+                ],
+                patterns: [{
+                    from: '**/*',
+                    to: 'nested/[path][name]-[hash:6].[ext]',
+                    transformPath: function(targetPath, absoluteFrom) {
+                        expect(absoluteFrom).to.have.string(HELPER_DIR);
+                        return targetPath.replace('nested/', 'transformed/');
+                    }
+                }]
+            })
+            .then(done)
+            .catch(done);
+        });
     });
 
     describe('with file in from', () => {
@@ -398,6 +441,23 @@ describe('apply function', () => {
                     transform: function(content, absoluteFrom) {
                         expect(absoluteFrom).to.equal(path.join(HELPER_DIR, 'file.txt'));
                         return content + 'changed';
+                    }
+                }]
+            })
+            .then(done)
+            .catch(done);
+        });
+
+        it('can transform target path', (done) => {
+            runEmit({
+                expectedAssetKeys: [
+                    'subdir/test.txt'
+                ],
+                patterns: [{
+                    from: 'file.txt',
+                    transformPath: function(targetPath, absoluteFrom) {
+                        expect(absoluteFrom).to.equal(path.join(HELPER_DIR, 'file.txt'));
+                        return targetPath.replace('file.txt', 'subdir/test.txt');
                     }
                 }]
             })
@@ -811,6 +871,25 @@ describe('apply function', () => {
                 ],
                 patterns: [{
                     from: 'directory'
+                }]
+            })
+            .then(done)
+            .catch(done);
+        });
+
+        it('can transform target path of every file in directory', (done) => {
+            runEmit({
+                expectedAssetKeys: [
+                    '/some/path/.dottedfile',
+                    '/some/path/directoryfile.txt',
+                    '/some/path/nestedfile.txt'
+                ],
+                patterns: [{
+                    from: 'directory',
+                    transformPath: function(targetPath, absoluteFrom) {
+                        expect(absoluteFrom).to.have.string(path.join(HELPER_DIR, 'directory'));
+                        return '/some/path/' + path.basename(targetPath);
+                    }
                 }]
             })
             .then(done)


### PR DESCRIPTION
Added a new function, `transformPath`, with which the target path can be modified programmatically. Decided to keep the functionality of `to` param unmodified so that path transfformation can be combined with templates for ease of use.
Should resolve #107.