### PR TITLE
feat: add support for copying file permissions (`options.copyPermissions`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A pattern looks like:
 | `ignore` | N | [] | Additional globs to ignore for this pattern |
 | `transform` | N | function(content, path) {<br>&nbsp;&nbsp;return content;<br>} | Function that modifies file contents before writing to webpack |
 | `force` | N | false | Overwrites files already in compilation.assets (usually added by other plugins) |
+|  copyPermissions | N | false | Applies source file permissions to destination files |
 
 #### Available options:
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import processPattern from './processPattern';
 import path from 'path';
 
 const fs = Promise.promisifyAll(require('fs')); // eslint-disable-line import/no-commonjs
+const constants = Promise.promisifyAll(require('constants')); // eslint-disable-line import/no-commonjs
 
 function CopyWebpackPlugin(patterns = [], options = {}) {
     if (!Array.isArray(patterns)) {
@@ -135,7 +136,10 @@ function CopyWebpackPlugin(patterns = [], options = {}) {
             _.forEach(written, function (value) {
                 if (value.copyPermissions) {
                     debug(`restoring permissions to ${value.webpackTo}`);
-                    const mask = fs.constants.S_IRWXU | fs.constants.S_IRWXG | fs.constants.S_IRWXO;
+
+                    let constsfrom = fs.constants || constants;
+
+                    const mask = constsfrom.S_IRWXU | constsfrom.S_IRWXG | constsfrom.S_IRWXO;
                     fs.chmodSync(path.join(output, value.webpackTo), value.perms & mask);
                 }
             });

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,9 @@ import Promise from 'bluebird';
 import _ from 'lodash';
 import preProcessPattern from './preProcessPattern';
 import processPattern from './processPattern';
+import path from 'path';
+
+const fs = Promise.promisifyAll(require('fs')); // eslint-disable-line import/no-commonjs
 
 function CopyWebpackPlugin(patterns = [], options = {}) {
     if (!Array.isArray(patterns)) {
@@ -118,6 +121,22 @@ function CopyWebpackPlugin(patterns = [], options = {}) {
                 } else {
                     debug(`adding ${context} to change tracking`);
                     compilation.contextDependencies.push(context);
+                }
+            });
+
+            // Copy permissions for files that requested it
+            let output = compiler.options.output.path;
+            if (output === '/' &&
+                compiler.options.devServer &&
+                compiler.options.devServer.outputPath) {
+                output = compiler.options.devServer.outputPath;
+            }
+
+            _.forEach(written, function (value) {
+                if (value.copyPermissions) {
+                    debug(`restoring permissions to ${value.webpackTo}`);
+                    const mask = fs.constants.S_IRWXU | fs.constants.S_IRWXG | fs.constants.S_IRWXO;
+                    fs.chmodSync(path.join(output, value.webpackTo), value.perms & mask);
                 }
             });
 

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -80,6 +80,19 @@ export default function writeFile(globalRef, pattern, file) {
                 return;
             }
 
+            let perms;
+            if (pattern.copyPermissions) {
+                debug(`saving permissions for '${file.absoluteFrom}'`);
+
+                written[file.absoluteFrom].copyPermissions = pattern.copyPermissions;
+                written[file.absoluteFrom].webpackTo = file.webpackTo;
+
+                perms |= stat.mode & fs.constants.S_IRWXU;
+                perms |= stat.mode & fs.constants.S_IRWXG;
+                perms |= stat.mode & fs.constants.S_IRWXO;
+                written[file.absoluteFrom].perms = perms;
+            }
+
             info(`writing '${file.webpackTo}' to compilation assets from '${file.absoluteFrom}'`);
             compilation.assets[file.webpackTo] = {
                 size: function() {

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -3,6 +3,7 @@ import loaderUtils from 'loader-utils';
 import path from 'path';
 
 const fs = Promise.promisifyAll(require('fs')); // eslint-disable-line import/no-commonjs
+const constants = Promise.promisifyAll(require('constants')); // eslint-disable-line import/no-commonjs
 
 export default function writeFile(globalRef, pattern, file) {
     const {info, debug, compilation, fileDependencies, written, copyUnmodified} = globalRef;
@@ -87,9 +88,12 @@ export default function writeFile(globalRef, pattern, file) {
                 written[file.absoluteFrom].copyPermissions = pattern.copyPermissions;
                 written[file.absoluteFrom].webpackTo = file.webpackTo;
 
-                perms |= stat.mode & fs.constants.S_IRWXU;
-                perms |= stat.mode & fs.constants.S_IRWXG;
-                perms |= stat.mode & fs.constants.S_IRWXO;
+                let constsfrom = fs.constants || constants;
+
+                perms |= stat.mode & constsfrom.S_IRWXU;
+                perms |= stat.mode & constsfrom.S_IRWXG;
+                perms |= stat.mode & constsfrom.S_IRWXO;
+
                 written[file.absoluteFrom].perms = perms;
             }
 


### PR DESCRIPTION
Add support for copying permissions for copied files.

Use a `copyPermissions: true` key in a copy pattern to turn it on.

Should resolve #35.