### PR TITLE
ci(travis): add node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "7"
+  - "8"
+  - "node"
+  - "lts/*"


### PR DESCRIPTION
Why:

* For better coverage of stability