### PR TITLE
refactor: use native `{Promise}` instead of `bluebird`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
       "requires": {
         "array-uniq": "1.0.3"
       }
@@ -149,8 +148,7 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.2.1",
@@ -162,8 +160,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "assertion-error": {
       "version": "1.0.2",
@@ -195,8 +192,8 @@
         "babel-register": "6.26.0",
         "babel-runtime": "6.26.0",
         "chokidar": "1.7.0",
-        "commander": "2.11.0",
-        "convert-source-map": "1.5.0",
+        "commander": "2.12.2",
+        "convert-source-map": "1.5.1",
         "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
         "lodash": "4.17.4",
@@ -234,7 +231,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
+        "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.4",
@@ -775,11 +772,6 @@
       "dev": true,
       "optional": true
     },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -964,9 +956,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
     "compare-func": {
@@ -1176,9 +1168,9 @@
       }
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
     "core-js": {
@@ -1231,7 +1223,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "dargs": {
@@ -1304,6 +1296,28 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "detect-indent": {
@@ -1320,6 +1334,15 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
+    },
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+      "requires": {
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
+      }
     },
     "doctrine": {
       "version": "1.5.0",
@@ -1355,9 +1378,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.35",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
-      "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+      "version": "0.10.37",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -1371,7 +1394,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1382,7 +1405,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1396,7 +1419,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1409,7 +1432,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "es6-weak-map": {
@@ -1419,7 +1442,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -1539,7 +1562,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "execa": {
@@ -1775,6 +1798,14 @@
       "requires": {
         "gitconfiglocal": "1.0.0",
         "pify": "2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "git-semver-tags": {
@@ -1872,17 +1903,16 @@
       "dev": true
     },
     "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
       "requires": {
         "array-union": "1.0.2",
-        "arrify": "1.0.1",
+        "dir-glob": "2.0.0",
         "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "ignore": "3.3.7",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -1948,8 +1978,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-      "dev": true
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2368,6 +2397,14 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "loader-utils": {
@@ -2805,6 +2842,14 @@
         "object-assign": "4.1.1"
       }
     },
+    "p-all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-1.0.0.tgz",
+      "integrity": "sha1-k731OlWiOCH9+pi0F0qZv38x340=",
+      "requires": {
+        "p-map": "1.2.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -2825,6 +2870,11 @@
       "requires": {
         "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
     },
     "parse-github-repo-url": {
       "version": "1.4.1",
@@ -2899,21 +2949,17 @@
       "dev": true
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "pify": "3.0.0"
       }
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -3033,6 +3079,25 @@
         "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
         "path-type": "1.1.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "read-pkg-up": {
@@ -3321,8 +3386,7 @@
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -3830,6 +3894,12 @@
           "requires": {
             "pify": "2.3.0"
           }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "build:tests": "babel tests/ --out-dir compiled_tests/ && ncp tests/helpers compiled_tests/helpers"
   },
   "dependencies": {
-    "bluebird": "^3.5.1",
-    "glob": "^7.1.2",
+    "globby": "^7.1.1",
     "is-glob": "^4.0.0",
     "loader-utils": "^0.2.15",
     "lodash": "^4.3.0",
-    "minimatch": "^3.0.4"
+    "minimatch": "^3.0.4",
+    "pify": "^3.0.0",
+    "p-limit": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",

--- a/src/preProcessPattern.js
+++ b/src/preProcessPattern.js
@@ -1,9 +1,8 @@
-import Promise from 'bluebird';
+import fs from 'fs';
+import pify from 'pify';
 import path from 'path';
 import _ from 'lodash';
 import isGlob from 'is-glob';
-
-const fs = Promise.promisifyAll(require('fs')); // eslint-disable-line import/no-commonjs
 
 // https://www.debuggex.com/r/VH2yS2mvJOitiyr3
 const isTemplateLike = /(\[ext\])|(\[name\])|(\[path\])|(\[folder\])|(\[emoji(:\d+)?\])|(\[(\w+:)?hash(:\w+)?(:\d+)?\])|(\[\d+\])/;
@@ -55,8 +54,7 @@ export default function preProcessPattern(globalRef, pattern) {
 
     debug(`determined '${pattern.from}' to be read from '${pattern.absoluteFrom}'`);
 
-    return fs
-    .statAsync(pattern.absoluteFrom)
+    return pify(fs.stat)(pattern.absoluteFrom)
     .catch(() => {
         // If from doesn't appear to be a glob, then log a warning
         if (isGlob(pattern.from) || pattern.from.indexOf('*') !== -1) {

--- a/src/processPattern.js
+++ b/src/processPattern.js
@@ -1,10 +1,9 @@
-import Promise from 'bluebird';
+import globby from 'globby';
+import pLimit from 'p-limit';
 import path from 'path';
 import _ from 'lodash';
 import minimatch from 'minimatch';
 import writeFile from './writeFile';
-
-const globAsync = Promise.promisify(require('glob')); // eslint-disable-line import/no-commonjs
 
 export default function processPattern(globalRef, pattern) {
     const {info, debug, output, concurrency} = globalRef;
@@ -16,73 +15,75 @@ export default function processPattern(globalRef, pattern) {
         return Promise.resolve();
     }
 
+    const limit = pLimit(concurrency || 100);
+
     info(`begin globbing '${pattern.absoluteFrom}' with a context of '${pattern.context}'`);
-    return globAsync(pattern.absoluteFrom, globArgs)
-    .map((fileFrom) => {
-        const file = {
-            force: pattern.force,
-            absoluteFrom: path.resolve(pattern.context, fileFrom)
-        };
-        file.relativeFrom = path.relative(pattern.context, file.absoluteFrom);
-
-        if (pattern.flatten) {
-            file.relativeFrom = path.basename(file.relativeFrom);
-        }
-
-        debug(`found ${fileFrom}`);
-
-        // Check the ignore list
-        let il = pattern.ignore.length;
-        while (il--) {
-            const ignoreGlob = pattern.ignore[il];
-
-            let globParams = {
-                dot: true,
-                matchBase: true
+    return globby(pattern.absoluteFrom, globArgs)
+        .then((paths) => Promise.all(paths.map((from) => limit(() => {
+            const file = {
+                force: pattern.force,
+                absoluteFrom: path.resolve(pattern.context, from)
             };
+            file.relativeFrom = path.relative(pattern.context, file.absoluteFrom);
 
-            let glob;
-            if (_.isString(ignoreGlob)) {
-                glob = ignoreGlob;
-            } else if (_.isObject(ignoreGlob)) {
-                glob = ignoreGlob.glob || '';
-                // Overwrite minimatch defaults
-                globParams = _.assign(globParams, _.omit(ignoreGlob, ['glob']));
-            } else {
-                glob = '';
+            if (pattern.flatten) {
+                file.relativeFrom = path.basename(file.relativeFrom);
             }
 
-            debug(`testing ${glob} against ${file.relativeFrom}`);
-            if (minimatch(file.relativeFrom, glob, globParams)) {
-                info(`ignoring '${file.relativeFrom}', because it matches the ignore glob '${glob}'`);
-                return;
-            } else {
-                debug(`${glob} doesn't match ${file.relativeFrom}`);
+            debug(`found ${from}`);
+
+            // Check the ignore list
+            let il = pattern.ignore.length;
+            while (il--) {
+                const ignoreGlob = pattern.ignore[il];
+
+                let globParams = {
+                    dot: true,
+                    matchBase: true
+                };
+
+                let glob;
+                if (_.isString(ignoreGlob)) {
+                    glob = ignoreGlob;
+                } else if (_.isObject(ignoreGlob)) {
+                    glob = ignoreGlob.glob || '';
+                    // Overwrite minimatch defaults
+                    globParams = _.assign(globParams, _.omit(ignoreGlob, ['glob']));
+                } else {
+                    glob = '';
+                }
+
+                debug(`testing ${glob} against ${file.relativeFrom}`);
+                if (minimatch(file.relativeFrom, glob, globParams)) {
+                    info(`ignoring '${file.relativeFrom}', because it matches the ignore glob '${glob}'`);
+                    return Promise.resolve();
+                } else {
+                    debug(`${glob} doesn't match ${file.relativeFrom}`);
+                }
             }
-        }
 
-        // Change the to path to be relative for webpack
-        if (pattern.toType === 'dir') {
-            file.webpackTo = path.join(pattern.to, file.relativeFrom);
-        } else if (pattern.toType === 'file') {
-            file.webpackTo = pattern.to || file.relativeFrom;
-        } else if (pattern.toType === 'template') {
-            file.webpackTo = pattern.to;
-        }
-
-        if (path.isAbsolute(file.webpackTo)) {
-            if (output === '/') {
-                throw '[copy-webpack-plugin] Using older versions of webpack-dev-server, devServer.outputPath must be defined to write to absolute paths';
+            // Change the to path to be relative for webpack
+            if (pattern.toType === 'dir') {
+                file.webpackTo = path.join(pattern.to, file.relativeFrom);
+            } else if (pattern.toType === 'file') {
+                file.webpackTo = pattern.to || file.relativeFrom;
+            } else if (pattern.toType === 'template') {
+                file.webpackTo = pattern.to;
             }
 
-            file.webpackTo = path.relative(output, file.webpackTo);
-        }
+            if (path.isAbsolute(file.webpackTo)) {
+                if (output === '/') {
+                    throw '[copy-webpack-plugin] Using older versions of webpack-dev-server, devServer.outputPath must be defined to write to absolute paths';
+                }
 
-        // ensure forward slashes
-        file.webpackTo = file.webpackTo.replace(/\\/g, '/');
+                file.webpackTo = path.relative(output, file.webpackTo);
+            }
 
-        info(`determined that '${fileFrom}' should write to '${file.webpackTo}'`);
+            // ensure forward slashes
+            file.webpackTo = file.webpackTo.replace(/\\/g, '/');
 
-        return writeFile(globalRef, pattern, file);
-    }, {concurrency: concurrency || 100}); // This is usually less than file read maximums while staying performant
+            info(`determined that '${from}' should write to '${file.webpackTo}'`);
+
+            return writeFile(globalRef, pattern, file);
+        }))));
 }

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -1,13 +1,12 @@
-import Promise from 'bluebird';
+import fs from 'fs';
+import pify from 'pify';
 import loaderUtils from 'loader-utils';
 import path from 'path';
-
-const fs = Promise.promisifyAll(require('fs')); // eslint-disable-line import/no-commonjs
 
 export default function writeFile(globalRef, pattern, file) {
     const {info, debug, compilation, fileDependencies, written, copyUnmodified} = globalRef;
 
-    return fs.statAsync(file.absoluteFrom)
+    return pify(fs.stat)(file.absoluteFrom)
     .then((stat) => {
         // We don't write empty directories
         if (stat.isDirectory()) {
@@ -20,7 +19,7 @@ export default function writeFile(globalRef, pattern, file) {
         }
 
         info(`reading ${file.absoluteFrom} to write to assets`);
-        return fs.readFileAsync(file.absoluteFrom)
+        return pify(fs.readFile)(file.absoluteFrom)
         .then((content) => {
             if (pattern.transform) {
                 content = pattern.transform(content, file.absoluteFrom);


### PR DESCRIPTION
Node which we support have native implementation `Promise`.