### PR TITLE
refactor(writeFile): use `data.toString()` instead of `JSON.stringify()` to serialize the `cache` data (`patterns.cache`) 

### DIFF
--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -47,16 +47,13 @@ export default function writeFile(globalRef, pattern, file) {
                     return cacache
                     .get(globalRef.cacheDir, cacheKey)
                     .then(
-                         (result) => JSON.parse(result.data),
+                         (result) => result.data,
                           () => {
                               return Promise
                               .resolve()
                               .then(() => transform(content, file.absoluteFrom))
-                              .then((content) => cacache.put(
-                                  globalRef.cacheDir,
-                                  cacheKey,
-                                  JSON.stringify(content)
-                               ).then(() => content));
+                              .then((content) => cacache.put(globalRef.cacheDir, cacheKey, content.toString())
+                              .then(() => content));
                           }
                      );
                 }


### PR DESCRIPTION
### `Notable Changes`

- `fs.readFile` return `{String|Buffer}`, JSON doesn't make sense here. Just `toString()` and save in cache