### PR TITLE
feat: use `compiler.inputFileSystem` instead `fs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-preset-es2015": "^6.6.0",
     "chai": "^3.4.0",
     "eslint": "^2.9.0",
+    "enhanced-resolve": "^3.4.1",
     "mocha": "^2.4.5",
     "ncp": "^2.0.0",
     "standard-version": "^4.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,7 @@ function CopyWebpackPlugin(patterns = [], options = {}) {
                 fileDependencies,
                 contextDependencies,
                 context,
+                inputFileSystem: compiler.inputFileSystem,
                 output: compiler.options.output.path,
                 ignore: options.ignore || [],
                 copyUnmodified: options.copyUnmodified,

--- a/src/preProcessPattern.js
+++ b/src/preProcessPattern.js
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import pify from 'pify';
 import path from 'path';
 import isGlob from 'is-glob';
@@ -9,7 +8,7 @@ import isObject from './utils/isObject';
 const isTemplateLike = /(\[ext\])|(\[name\])|(\[path\])|(\[folder\])|(\[emoji(:\d+)?\])|(\[(\w+:)?hash(:\w+)?(:\d+)?\])|(\[\d+\])/;
 
 export default function preProcessPattern(globalRef, pattern) {
-    const {info, debug, warning, context,
+    const {info, debug, warning, context, inputFileSystem,
         fileDependencies, contextDependencies, compilation} = globalRef;
 
     pattern = typeof pattern === 'string' ? {
@@ -59,7 +58,7 @@ export default function preProcessPattern(globalRef, pattern) {
 
     debug(`determined '${pattern.from}' to be read from '${pattern.absoluteFrom}'`);
 
-    return pify(fs.stat)(pattern.absoluteFrom)
+    return pify(inputFileSystem).stat(pattern.absoluteFrom)
     .catch(() => {
         // If from doesn't appear to be a glob, then log a warning
         if (isGlob(pattern.from) || pattern.from.indexOf('*') !== -1) {

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import pify from 'pify';
 import loaderUtils from 'loader-utils';
 import path from 'path';
@@ -8,9 +7,9 @@ import { name, version } from '../package.json';
 import findCacheDir from 'find-cache-dir';
 
 export default function writeFile(globalRef, pattern, file) {
-    const {info, debug, compilation, fileDependencies, written, copyUnmodified} = globalRef;
+    const {info, debug, compilation, fileDependencies, written, inputFileSystem, copyUnmodified} = globalRef;
 
-    return pify(fs.stat)(file.absoluteFrom)
+    return pify(inputFileSystem).stat(file.absoluteFrom)
     .then((stat) => {
         // We don't write empty directories
         if (stat.isDirectory()) {
@@ -23,7 +22,7 @@ export default function writeFile(globalRef, pattern, file) {
         }
 
         info(`reading ${file.absoluteFrom} to write to assets`);
-        return pify(fs.readFile)(file.absoluteFrom)
+        return pify(inputFileSystem).readFile(file.absoluteFrom)
         .then((content) => {
             if (pattern.transform) {
                 const transform = (content, absoluteFrom) => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,6 +2,8 @@
 import {
     expect
 } from 'chai';
+import NodeJsInputFileSystem from 'enhanced-resolve/lib/NodeJsInputFileSystem';
+import CachedInputFileSystem from 'enhanced-resolve/lib/CachedInputFileSystem';
 
 // ensure we don't mess up classic imports
 const CopyWebpackPlugin = require('./../dist/index');
@@ -31,6 +33,8 @@ class MockCompiler {
                 outputPath: options.devServer.outputPath
             };
         }
+
+        this.inputFileSystem = new CachedInputFileSystem(new NodeJsInputFileSystem(), 0);
 
         this.outputFileSystem = {
             constructor: {


### PR DESCRIPTION
### `Notable Changes`

Also it is improve perf, because `webpack` cache `stats` and other stuff (https://github.com/webpack/webpack/blob/efc576c8b744e7a015ab26f1f46932ba3ca7d4f1/lib/node/NodeEnvironmentPlugin.js#L14) using `CachedInputFileSystem`

### `Issues`

- Closes https://github.com/webpack-contrib/copy-webpack-plugin/issues/204