### PR TITLE
fix: replace `pify` with simpler promise helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "is-glob": "^4.0.0",
     "loader-utils": "^0.2.15",
     "minimatch": "^3.0.4",
-    "pify": "^3.0.0",
     "p-limit": "^1.0.0"
   },
   "devDependencies": {

--- a/src/preProcessPattern.js
+++ b/src/preProcessPattern.js
@@ -1,8 +1,8 @@
-import pify from 'pify';
 import path from 'path';
 import isGlob from 'is-glob';
 import escape from './utils/escape';
 import isObject from './utils/isObject';
+import { stat } from './utils/promisify';
 
 // https://www.debuggex.com/r/VH2yS2mvJOitiyr3
 const isTemplateLike = /(\[ext\])|(\[name\])|(\[path\])|(\[folder\])|(\[emoji(:\d+)?\])|(\[(\w+:)?hash(:\w+)?(:\d+)?\])|(\[\d+\])/;
@@ -58,7 +58,7 @@ export default function preProcessPattern(globalRef, pattern) {
 
     debug(`determined '${pattern.from}' to be read from '${pattern.absoluteFrom}'`);
 
-    return pify(inputFileSystem).stat(pattern.absoluteFrom)
+    return stat(inputFileSystem, pattern.absoluteFrom)
     .catch(() => {
         // If from doesn't appear to be a glob, then log a warning
         if (isGlob(pattern.from) || pattern.from.indexOf('*') !== -1) {

--- a/src/utils/promisify.js
+++ b/src/utils/promisify.js
@@ -1,0 +1,21 @@
+export const stat = (inputFileSystem, path) => {
+    return new Promise((resolve, reject) => {
+        inputFileSystem.stat(path, (err, stats) => {
+            if (err) {
+                reject(err);
+            }
+            resolve(stats);
+        });
+    });
+}
+
+export const readFile = (inputFileSystem, path) => {
+    return new Promise((resolve, reject) => {
+        inputFileSystem.readFile(path, (err, stats) => {
+            if (err) {
+                reject(err);
+            }
+            resolve(stats);
+        });
+    });
+}

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -1,15 +1,15 @@
-import pify from 'pify';
 import loaderUtils from 'loader-utils';
 import path from 'path';
 import cacache from 'cacache';
 import serialize from 'serialize-javascript';
 import { name, version } from '../package.json';
 import findCacheDir from 'find-cache-dir';
+import { stat, readFile } from './utils/promisify';
 
 export default function writeFile(globalRef, pattern, file) {
     const {info, debug, compilation, fileDependencies, written, inputFileSystem, copyUnmodified} = globalRef;
 
-    return pify(inputFileSystem).stat(file.absoluteFrom)
+    return stat(inputFileSystem, file.absoluteFrom)
     .then((stat) => {
         // We don't write empty directories
         if (stat.isDirectory()) {
@@ -22,7 +22,7 @@ export default function writeFile(globalRef, pattern, file) {
         }
 
         info(`reading ${file.absoluteFrom} to write to assets`);
-        return pify(inputFileSystem).readFile(file.absoluteFrom)
+        return readFile(inputFileSystem, file.absoluteFrom)
         .then((content) => {
             if (pattern.transform) {
                 const transform = (content, absoluteFrom) => {


### PR DESCRIPTION
`pify` seems to not be working correctly when a decorated file system is used as `inputFileSystem`.

Fix #217