### PR TITLE
feat(processPattern): add support for `{RegExp)` matches (`pattern.test`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Or, in case of just a `from` with the default destination, you can also use a `{
 |[`fromArgs`](#fromArgs)|`{Object}`|`{ cwd: context }`|See the [`node-glob` options](https://github.com/isaacs/node-glob#options) in addition to the ones below|
 |[`to`](#to)|`{String\|Object}`|`undefined`|Output root if `from` is file or dir, resolved glob path if `from` is glob|
 |[`toType`](#toType)|`{String}`|``|[toType Options](#toType)|
+|[`test`](#test)|`{RegExp}`|``|Pattern for extracting elements to be used in `to` templates|
 |[`force`](#force)|`{Boolean}`|`false`|Overwrites files already in `compilation.assets` (usually added by other plugins/loaders)|
 |[`ignore`](#ignore)|`{Array}`|`[]`|Globs to ignore for this pattern|
 |`flatten`|`{Boolean}`|`false`|Removes all directory references and only copies file names.⚠️ If files have the same name, the result is non-deterministic|
@@ -138,6 +139,27 @@ Or, in case of just a `from` with the default destination, you can also use a `{
       from: 'src/'
       to: 'dest/[name].[hash].[ext]',
       toType: 'template'
+    }
+  ], options)
+]
+```
+
+### `test`
+
+Defines a `{RegExp}` to match some parts of the file path.
+These capture groups can be reused in the name property using `[N]` placeholder.
+Note that `[0]` will be replaced by the entire path of the file,
+whereas `[1]` will contain the first capturing parenthesis of your `{RegExp}`
+and so on...
+
+**webpack.config.js**
+```js
+[
+  new CopyWebpackPlugin([
+    {
+      from: '*/*',
+      to: '[1]-[2].[hash].[ext]',
+      test: /([^/]+)\/(.+)\.png$/
     }
   ], options)
 ]

--- a/src/processPattern.js
+++ b/src/processPattern.js
@@ -72,6 +72,7 @@ export default function processPattern(globalRef, pattern) {
                 file.webpackTo = pattern.to || file.relativeFrom;
             } else if (pattern.toType === 'template') {
                 file.webpackTo = pattern.to;
+                file.webpackToRegExp = pattern.test;
             }
 
             if (path.isAbsolute(file.webpackTo)) {

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -78,6 +78,7 @@ export default function writeFile(globalRef, pattern, file) {
                     file.webpackTo,
                     {
                         content,
+                        regExp: file.webpackToRegExp,
                         context: pattern.context
                     }
                 );

--- a/tests/index.js
+++ b/tests/index.js
@@ -441,6 +441,23 @@ describe('apply function', () => {
             .then(done)
             .catch(done);
         });
+
+        it('can flatten or normalize glob matches', (done) => {
+            runEmit({
+                expectedAssetKeys: [
+                    '[special?directory]-(special-*file).txt',
+                    '[special?directory]-directoryfile.txt',
+                    'directory-directoryfile.txt'
+                ],
+                patterns: [{
+                    from: '*/*.*',
+                    test: /([^\/]+)\/([^\/]+)\.\w+$/,
+                    to: '[1]-[2].[ext]'
+                }]
+            })
+            .then(done)
+            .catch(done);
+        });
     });
 
     describe('with file in from', () => {


### PR DESCRIPTION
We want to match some of our existing asset logic which generates image file names from the source paths. Having a function that generates those paths seemed like the simplest solution.

This mirrors the way the `file-loader` works, allowing to reuse logic. https://github.com/webpack-contrib/file-loader#regexp