### PR TITLE
docs(README): clarify `{Promise}` usage (`pattern.transform`) (#160)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Or, in case of just a `from` with the default destination, you can also use a `{
 |[`force`](#force)|`{Boolean}`|`false`|Overwrites files already in `compilation.assets` (usually added by other plugins/loaders)|
 |[`ignore`](#ignore)|`{Array}`|`[]`|Globs to ignore for this pattern|
 |`flatten`|`{Boolean}`|`false`|Removes all directory references and only copies file names.⚠️ If files have the same name, the result is non-deterministic|
-|[`transform`](#transform)|`{Function}`|`(content, path) => content`|Function that modifies file contents before copying|
+|[`transform`](#transform)|`{Function}`|`(content, path) => content`|Function that modifies file contents before copying. This function may return a Promise too.|
 |[`cache`](#cache)|`{Boolean\|Object}`|`false`|Enable `transform` caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache|
 |[`context`](#context)|`{String}`|`options.context \|\| compiler.options.context`|A path that determines how to interpret the `from` path|
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Or, in case of just a `from` with the default destination, you can also use a `{
 |[`force`](#force)|`{Boolean}`|`false`|Overwrites files already in `compilation.assets` (usually added by other plugins/loaders)|
 |[`ignore`](#ignore)|`{Array}`|`[]`|Globs to ignore for this pattern|
 |`flatten`|`{Boolean}`|`false`|Removes all directory references and only copies file names.⚠️ If files have the same name, the result is non-deterministic|
-|[`transform`](#transform)|`{Function}`|`(content, path) => content`|Function that modifies file contents before copying. This function may return a Promise too.|
+|[`transform`](#transform)|`{Function\|Promise}`|`(content, path) => content`|Function or Promise that modifies file contents before copying|
 |[`cache`](#cache)|`{Boolean\|Object}`|`false`|Enable `transform` caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache|
 |[`context`](#context)|`{String}`|`options.context \|\| compiler.options.context`|A path that determines how to interpret the `from` path|
 
@@ -200,6 +200,8 @@ and so on...
 
 ### `transform`
 
+#### `{Function}`
+
 **webpack.config.js**
 ```js
 [
@@ -211,6 +213,23 @@ and so on...
         return optimize(content)
       }
     }
+  ], options)
+]
+```
+
+#### `{Promise}`
+
+**webpack.config.js**
+```js
+[
+  new CopyWebpackPlugin([
+    {
+      from: 'src/*.png',
+      to: 'dest/',
+      transform (content, path) {
+        return Promise.resolve(optimize(content))
+      }
+  }
   ], options)
 ]
 ```


### PR DESCRIPTION
fixes #160
Edit transform documentation to specify that a Promise may be returned.