### PR TITLE
feat: add `merge` method (`pattern.merge`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Or, in case of just a `from` with the default destination, you can also use a `{
 |[`ignore`](#ignore)|`{Array}`|`[]`|Globs to ignore for this pattern|
 |`flatten`|`{Boolean}`|`false`|Removes all directory references and only copies file names.⚠️ If files have the same name, the result is non-deterministic|
 |[`transform`](#transform)|`{Function\|Promise}`|`(content, path) => content`|Function or Promise that modifies file contents before copying|
+|[`merge`](#merge)|`{Function}`|`(existingContent, content, path) => content`|Function that merges content to the content already in compilation. Cannot be used with `force`.|
 |[`cache`](#cache)|`{Boolean\|Object}`|`false`|Enable `transform` caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache|
 |[`context`](#context)|`{String}`|`options.context \|\| compiler.options.context`|A path that determines how to interpret the `from` path|
 
@@ -230,6 +231,23 @@ and so on...
         return Promise.resolve(optimize(content))
       }
   }
+  ], options)
+]
+```
+
+### `merge`
+
+**webpack.config.js**
+```js
+[
+  new CopyWebpackPlugin([
+    {
+      from: 'src/*.png',
+      to: 'dest/',
+      merge (existingContent, content, path) {
+        return merge(existingContent, content)
+      }
+    }
   ], options)
 ]
 ```

--- a/src/preProcessPattern.js
+++ b/src/preProcessPattern.js
@@ -14,6 +14,9 @@ export default function preProcessPattern(globalRef, pattern) {
     pattern = typeof pattern === 'string' ? {
         from: pattern
     } : Object.assign({}, pattern);
+    if (pattern.force && pattern.merge) {
+        throw new Error('[copy-webpack-plugin] patterns cannot have both force and merge defined');
+    }
     pattern.to = pattern.to || '';
     pattern.context = pattern.context || context;
     if (!path.isAbsolute(pattern.context)) {

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -100,9 +100,20 @@ export default function writeFile(globalRef, pattern, file) {
                 };
             }
 
-            if (compilation.assets[file.webpackTo] && !file.force) {
-                info(`skipping '${file.webpackTo}', because it already exists`);
-                return;
+            if (compilation.assets[file.webpackTo]) {
+                if (pattern.merge) {
+                    info(`merging '${file.absoluteFrom}' to compilation asset '${file.webpackTo}'`);
+                    let totalSize = compilation.assets[file.webpackTo].size() + stat.size;
+                    let mergedContent = pattern.merge(compilation.assets[file.webpackTo].source(), content, file.absoluteFrom);
+                    compilation.assets[file.webpackTo] = {
+                        size: function() { return totalSize; },
+                        source: function() { return mergedContent; }
+                    };
+                    return;
+                } else if (!file.force) {
+                    info(`skipping '${file.webpackTo}', because it already exists`);
+                    return;
+                }
             }
 
             info(`writing '${file.webpackTo}' to compilation assets from '${file.absoluteFrom}'`);

--- a/tests/index.js
+++ b/tests/index.js
@@ -494,6 +494,46 @@ describe('apply function', () => {
             .catch(done);
         });
 
+        it('can merge files', (done) => {
+            runEmit({
+                expectedAssetKeys: [
+                    'merged.txt'
+                ],
+                expectedAssetContent: {
+                    'merged.txt': './new, directory/new'
+                },
+                options: {
+                    ignore: ['\\[special\\?directory\\]/**/*']
+                },
+                patterns: [{
+                    from: '**/*.txt',
+                    to: 'merged.txt',
+                    transform: function(content, absoluteFrom) {
+                        if (!content.length) {
+                            return content;
+                        }
+                        const relativePath = path.relative(HELPER_DIR, absoluteFrom);
+                        let segment = path.dirname(relativePath);
+                        return `${segment}/${content}`;
+                    },
+                    merge: function(content1, content2) {
+                        if (!content1.length) {
+                            return content2;
+                        }
+                        if (!content2.length) {
+                            return content1;
+                        }
+                        if (content1.length < content2.length)
+                            return `${content1}, ${content2}`;
+                        else
+                            return `${content2}, ${content1}`;
+                    }
+                }]
+            })
+            .then(done)
+            .catch(done);
+        });
+
         it('warns when file not found', (done) => {
             runEmit({
                 expectedAssetKeys: [],


### PR DESCRIPTION
Here is the second try of adding the `merge` options to patterns. Previous had rebase issues.

It can be used to combine multiple files into a single one. Example of use would be combining multiple json config or localization files:
Input: **config.json:**
```json
{
  "field1": "value1"
}
```
Input: **subfolder/config.json**
```json
{
  "field2": "value2"
}
```
Result **config.json**
```json
{
  "field1": "value1",
  "subfolder": {
    "field2": "value2"
  }
}
```

This functionality is been used in our internal solution for merging configuration json files (each section has it's own config file which gets merged on build) as well as translation json files (each feature has a separate resources file which are merged on build).

Due to initial delay with PR resolving, I created package [copy-webpack-plugin-advanced](https://www.npmjs.com/package/copy-webpack-plugin-advanced) which has around 1000 weekly downloads which justifies need for this method in the original package.

Please find previous PR here: https://github.com/webpack-contrib/copy-webpack-plugin/pull/103