### PR TITLE
feat(preProcessPattern): resolve patterns using node's module resolution algorithm

### DIFF
--- a/src/preProcessPattern.js
+++ b/src/preProcessPattern.js
@@ -60,7 +60,7 @@ export default function preProcessPattern(globalRef, pattern) {
     debug(`determined '${pattern.from}' to be read from '${pattern.absoluteFrom}'`);
 
     return stat(inputFileSystem, pattern.absoluteFrom)
-    .catch(() => {
+    .catch((err) => {
         if (isGlob(pattern.from) || pattern.from.indexOf('*') !== -1) {
             // If it is a glob, then no worries if it does not exist in the file system
             pattern.fromType = 'glob';
@@ -69,10 +69,12 @@ export default function preProcessPattern(globalRef, pattern) {
             // Try the node module resolution algorithm to find the module
             pattern.absoluteFrom = require.resolve(pattern.from);
             return stat(inputFileSystem, pattern.absoluteFrom);
+        } else {
+            throw err;
         }
     })
     .catch(() => {
-        // If from doesn't appear to be a glob, then log a warning
+        // Log a warning if the file cannot be located
         const msg = `unable to locate '${pattern.from}' at '${pattern.absoluteFrom}'`;
         warning(msg);
         compilation.errors.push(`[copy-webpack-plugin] ${msg}`);

--- a/tests/index.js
+++ b/tests/index.js
@@ -474,6 +474,19 @@ describe('apply function', () => {
             .catch(done);
         });
 
+        it('can resolve modules using the Node module resolution algorithm', (done) => {
+            runEmit({
+                expectedAssetKeys: [
+                    'package.json'
+                ],
+                patterns: [{
+                    from: 'globby/package.json'
+                }]
+            })
+            .then(done)
+            .catch(done);
+        });
+
         it('can transform a file', (done) => {
             runEmit({
                 expectedAssetKeys: [


### PR DESCRIPTION
I think it would be very useful for this plugin to also allow you to copy assets from Node packages.

It's not as easy as setting `context` to `path.resolve(__dirname, 'node_modules')`. Node has an established [module resolution algorithm](https://nodejs.org/api/modules.html#modules_all_together) that starts at the current directory and traverses up the parents until it either finds the module in a parent's `node_modules` subdirectory or reaches the root directory.

[Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) and [Lerna](https://lernajs.io/) enable developers to manage multiple projects in the same repository and improve dependency installation times by consolidating dependencies that are shared by more than one project in the repo in a `node_modules` directory in the repository root. This is a common example of where a project in a workspace may want to copy an asset from a Node package it has installed, but the asset may exist at `/<pathToRepo>/projects/<project>/node_modules/<package>/<pathToAsset>`, or it might exist at `/<pathToRepo>/node_modules/<package>/<pathToAsset>`.

[`require.resolve`](https://nodejs.org/api/modules.html#modules_require_resolve_request_options), given a request, will resolve with absolute path to the requested asset or throw if the module does not exist in any of the parents' `node_modules` directories.