### PR TITLE
docs(README): Context option is a string, not array

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ and so on...
 [
   new CopyWebpackPlugin(
     [ ...patterns ],
-    { context: [ '/app' ] }
+    { context: '/app' }
   )
 ]
 ```


### PR DESCRIPTION
Following the example, webpack emits an error

```sh
TypeError: Path must be a string.
```

Replaced with string, which actually works fine in the latest webpack 4.15.0