### PR TITLE
feat: add support for target path transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Or, in case of just a `from` with the default destination, you can also use a `{
 |[`ignore`](#ignore)|`{Array}`|`[]`|Globs to ignore for this pattern|
 |`flatten`|`{Boolean}`|`false`|Removes all directory references and only copies file names.⚠️ If files have the same name, the result is non-deterministic|
 |[`transform`](#transform)|`{Function\|Promise}`|`(content, path) => content`|Function or Promise that modifies file contents before copying|
+|[`transformPath`](#transformPath)|`{Function\|Promise}`|`(targetPath, sourcePath) => path`|Function or Promise that modifies file writing path|
 |[`cache`](#cache)|`{Boolean\|Object}`|`false`|Enable `transform` caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache|
 |[`context`](#context)|`{String}`|`options.context \|\| compiler.options.context`|A path that determines how to interpret the `from` path|
 
@@ -233,6 +234,43 @@ and so on...
   ], options)
 ]
 ```
+
+### `transformPath`
+
+#### `{Function}`
+
+**webpack.config.js**
+```js
+[
+  new CopyWebpackPlugin([
+    {
+      from: 'src/*.png',
+      to: 'dest/',
+      transformPath (targetPath, absolutePath) {
+        return 'newPath';
+      }
+    }
+  ], options)
+]
+```
+
+#### `{Promise}`
+
+**webpack.config.js**
+```js
+[
+  new CopyWebpackPlugin([
+    {
+      from: 'src/*.png',
+      to: 'dest/',
+      transform (targePath, absolutePath) {
+        return Promise.resolve('newPath')
+      }
+  }
+  ], options)
+]
+```
+
 
 ### `cache`
 

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -63,8 +63,6 @@ export default function writeFile(globalRef, pattern, file) {
 
             return content;
         }).then((content) => {
-            const hash = loaderUtils.getHashDigest(content);
-
             if (pattern.toType === 'template') {
                 info(`interpolating template '${file.webpackTo}' for '${file.relativeFrom}'`);
 
@@ -84,6 +82,20 @@ export default function writeFile(globalRef, pattern, file) {
                     }
                 );
             }
+            
+            return content;
+        }).then((content) => {
+            if (pattern.transformPath) {
+                return Promise.resolve(
+                    pattern.transformPath(file.webpackTo, file.absoluteFrom)
+                ).then((newPath) => {
+                    file.webpackTo = newPath;
+                }).then(() => content);
+            }
+            
+            return content;
+        }).then((content) => {
+            const hash = loaderUtils.getHashDigest(content);
 
             if (!copyUnmodified &&
                 written[file.absoluteFrom] &&


### PR DESCRIPTION
updated version of the PR: webpack-contrib/copy-webpack-plugin/pull/115.

Should resolve #107.

> Why another PR?
>
> Since the other PR is not being updated for some time, and needed to be updated for some time, since I did some differences (mostly to allow Promises with transformPath will need a review)

differences:
- added support to Promises to be aligned with transform (since transform supports Promises)
- updated the tests since there are more test files test files
- updated the Readme to include implementation examples (Function & Promise) like transform in the Readme
- rebased with the latest version
 