### PR TITLE
fix(preProcessPattern): throw an `{Error}` if `pattern.from` is empty or `undefined`

### DIFF
--- a/src/preProcessPattern.js
+++ b/src/preProcessPattern.js
@@ -14,6 +14,9 @@ export default function preProcessPattern(globalRef, pattern) {
     pattern = typeof pattern === 'string' ? {
         from: pattern
     } : Object.assign({}, pattern);
+    if (pattern.from === '') {
+        throw new Error('[copy-webpack-plugin] path "from" cannot be empty string');
+    }
     pattern.to = pattern.to || '';
     pattern.context = pattern.context || context;
     if (!path.isAbsolute(pattern.context)) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -227,6 +227,16 @@ describe('apply function', () => {
 
             expect(createPluginWithNull).to.throw(Error);
         });
+
+        it('throws an error if the "from" path is an empty string', () => {
+            const createPluginWithNull = () => {
+                CopyWebpackPlugin({
+                    from: ''
+                });
+            };
+
+            expect(createPluginWithNull).to.throw(Error);
+        });
     });
 
     describe('with glob in from', () => {
@@ -1434,7 +1444,7 @@ describe('apply function', () => {
                         patterns: [{
                             from: '.'
                         }]
-    
+
                     })
                     .then(done)
                     .catch(done);


### PR DESCRIPTION
### Type

- [x] Fix

### Issues

- Fixes #278 

### SemVer

- [x] Patch