### PR TITLE
fix(processPattern): add `glob` directory context to `contextDependencies`

### DIFF
--- a/src/processPattern.js
+++ b/src/processPattern.js
@@ -6,7 +6,7 @@ import writeFile from './writeFile';
 import isObject from './utils/isObject';
 
 export default function processPattern(globalRef, pattern) {
-    const {info, debug, output, concurrency} = globalRef;
+    const {info, debug, output, concurrency, contextDependencies} = globalRef;
     const globArgs = Object.assign({
         cwd: pattern.context
     }, pattern.fromArgs || {});
@@ -28,6 +28,13 @@ export default function processPattern(globalRef, pattern) {
 
             if (pattern.flatten) {
                 file.relativeFrom = path.basename(file.relativeFrom);
+            }
+
+            // This is so webpack is able to watch the directory and when
+            // a new file is added it triggeres a rebuild
+            const contextPath = path.dirname(path.resolve(from));
+            if (contextDependencies.indexOf(contextPath) === -1) {
+                contextDependencies.push(contextPath);
             }
 
             debug(`found ${from}`);

--- a/tests/index.js
+++ b/tests/index.js
@@ -472,6 +472,22 @@ describe('apply function', () => {
             .then(done)
             .catch(done);
         });
+
+        it('adds the directory to the watch list when using glob', (done) => {
+            run({
+                patterns: [{
+                    from: 'directory/**/*'
+                }]
+            })
+            .then((compilation) => {
+                const absFrom = path.resolve(HELPER_DIR, 'directory');
+                const absFromNested = path.resolve(HELPER_DIR, 'directory', 'nested');
+                expect(compilation.contextDependencies).to.have.members([absFrom, absFromNested]);
+            })
+            .then(done)
+            .catch(done);
+        });
+
     });
 
     describe('with file in from', () => {
@@ -1196,9 +1212,9 @@ describe('apply function', () => {
                 }]
             })
             .then((compilation) => {
-                const absFrom = path.join(HELPER_DIR, 'directory');
-
-                expect(compilation.contextDependencies).to.have.members([absFrom]);
+                const absFrom = path.resolve(HELPER_DIR, 'directory');
+                const absFromNested = path.resolve(HELPER_DIR, 'directory', 'nested');
+                expect(compilation.contextDependencies).to.have.members([absFrom, absFromNested]);
             })
             .then(done)
             .catch(done);


### PR DESCRIPTION
At the moment when using globs with `watch` mode and files are added after the initial compilation, they are not copied because the globbed `dirname` is not added to the context