### PR TITLE
fix(processPattern): don't add `'glob'` as directory when it is a file (`contextDependencies`)

### DIFF
--- a/src/processPattern.js
+++ b/src/processPattern.js
@@ -1,5 +1,6 @@
 import globby from 'globby';
 import pLimit from 'p-limit';
+import isGlob from 'is-glob';
 import path from 'path';
 import minimatch from 'minimatch';
 import writeFile from './writeFile';
@@ -33,7 +34,7 @@ export default function processPattern(globalRef, pattern) {
             // This is so webpack is able to watch the directory and when
             // a new file is added it triggeres a rebuild
             const contextPath = path.dirname(path.resolve(from));
-            if (contextDependencies.indexOf(contextPath) === -1) {
+            if (contextDependencies.indexOf(contextPath) === -1 && isGlob(pattern.glob)) {
                 contextDependencies.push(contextPath);
             }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -488,6 +488,21 @@ describe('apply function', () => {
             .catch(done);
         });
 
+        it('does not add the directory to the watch list when glob is a file', (done) => {
+            run({
+                patterns: [{
+                    from: {
+                        glob: 'directory/directoryfile.txt'
+                    }
+                }]
+            })
+            .then((compilation) => {
+                const absFrom = path.resolve(HELPER_DIR, 'directory');
+                expect(compilation.contextDependencies).to.not.have.members([absFrom]);
+            })
+            .then(done)
+            .catch(done);
+        });
     });
 
     describe('with file in from', () => {


### PR DESCRIPTION
In some cases we might have someone like this which in that cause we wouldn't want to add the parent directory as a webpack context dependencies
```
{
  ignore: [ '.gitkeep', '**/.DS_Store', '**/Thumbs.db' ],
  from: { glob: 'favicon.ico', dot: true },
  toType: 'dir',
  fromType: 'glob'
}
```
