### PR TITLE
docs(README): fix function name `transformPath` in code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ and so on...
     {
       from: 'src/*.png',
       to: 'dest/',
-      transform (targePath, absolutePath) {
+      transformPath (targePath, absolutePath) {
         return Promise.resolve('newPath')
       }
   }


### PR DESCRIPTION
The example for `transformPath`(`Promise`) uses `transform`, fixed that.