### PR TITLE
Support for manifest plugin and other modules utilizing moduleAsset hook

### DIFF
--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -117,6 +117,12 @@ export default function writeFile(globalRef, pattern, file) {
                 return;
             }
 
+            // Used to announce these files as moduleAssets.
+            // This allows the paths to be resolved by things like the manifest plugin
+            compilation.hooks.moduleAsset.call({
+                userRequest: file.relativeFrom
+            }, file.webpackTo);
+
             info(`writing '${file.webpackTo}' to compilation assets from '${file.absoluteFrom}'`);
             compilation.assets[file.webpackTo] = {
                 size: function() {


### PR DESCRIPTION
It's stupid simple. Announce to moduleAsset hook. Now original reference name links to new asset name. I'm sure this will help resolve other related conflicts with plugins and post processing against asset paths.

Issue #104