### PR TITLE
test: empty from

### DIFF
--- a/test/CopyPlugin.test.js
+++ b/test/CopyPlugin.test.js
@@ -871,6 +871,20 @@ describe('apply function', () => {
         .catch(done);
     });
 
+    it('warns when pattern is empty', (done) => {
+      runEmit({
+        expectedAssetKeys: [],
+        expectedErrors: [new Error(`path "from" cannot be empty string`)],
+        patterns: [
+          {
+            from: '',
+          },
+        ],
+      })
+        .then(done)
+        .catch(done);
+    });
+
     it('can use an absolute path to move a file to the root directory', (done) => {
       const absolutePath = path.resolve(HELPER_DIR, 'file.txt');
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Tests

### Breaking Changes

We merge this before as fix, before you can use empty pattern (it is mean current context), this behavior is misleading so better avoid this.

### Additional Info

No