### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ module.exports = {
 
 |                Name                 |    Type     |          Default           | Description                                                                                                                                       |
 | :---------------------------------: | :---------: | :------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------ |
-|       [`logLevel`](#logLevel)       | `{String}`  |      **`'warning'`**       | Level of messages that the module will log                                                                                                        |
+|       [`logLevel`](#logLevel)       | `{String}`  |      **`'warn'`**       | Level of messages that the module will log                                                                                                        |
 |         [`ignore`](#ignore)         |  `{Array}`  |            `[]`            | Array of globs to ignore (applied to `from`)                                                                                                      |
 |        [`context`](#context)        | `{String}`  | `compiler.options.context` | A path that determines how to interpret the `from` path, shared for all patterns                                                                  |
 | [`copyUnmodified`](#copyUnmodified) | `{Boolean}` |          `false`           | Copies files, regardless of modification when using watch or `webpack-dev-server`. All files are copied on first build, regardless of this option |


### PR DESCRIPTION
Fix a typo in README.md. `'warning'` should be `'warn'`.

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Just fix a typo.

### Breaking Changes

No.

### Additional Info

No.
