### PR TITLE
feat: treat [hash] and [contenthash] as expected in webpack (#349)

### DIFF
--- a/test/CopyPlugin.test.js
+++ b/test/CopyPlugin.test.js
@@ -112,6 +112,10 @@ describe('apply function', () => {
           warnings: [],
           fileDependencies: new Set(),
           contextDependencies: new Set(),
+          outputOptions: {
+            hashDigest: 'hex',
+            hashFunction: 'md5',
+          },
         },
         opts.compilation
       );
@@ -481,7 +485,7 @@ describe('apply function', () => {
         patterns: [
           {
             from: '**/*',
-            to: 'nested/[path][name]-[hash:6].[ext]',
+            to: 'nested/[path][name]-[contenthash:6].[ext]',
             transformPath(targetPath, absoluteFrom) {
               expect(absoluteFrom.includes(HELPER_DIR)).toBe(true);
 
@@ -626,7 +630,7 @@ describe('apply function', () => {
         .catch(done);
     });
 
-    it('can use a glob to move multiple files to a non-root directory with name, hash and ext', (done) => {
+    it('can use a glob to move multiple files to a non-root directory with name, contenthash and ext', (done) => {
       runEmit({
         expectedAssetKeys: [
           'nested/[!]/hello-d41d8c.txt',
@@ -647,7 +651,7 @@ describe('apply function', () => {
         patterns: [
           {
             from: '**/*',
-            to: 'nested/[path][name]-[hash:6].[ext]',
+            to: 'nested/[path][name]-[contenthash:6].[ext]',
           },
         ],
       })
@@ -1290,13 +1294,27 @@ describe('apply function', () => {
         .catch(done);
     });
 
-    it('allows pattern to contain name, hash or ext', (done) => {
+    it('allows pattern to contain name, hash, contenthash or ext', (done) => {
       runEmit({
-        expectedAssetKeys: ['directory/directoryfile-22af64.txt'],
+        expectedAssetKeys: ['directory/d41d8c/directoryfile-22af64.txt'],
         patterns: [
           {
             from: 'directory/directoryfile.txt',
-            to: 'directory/[name]-[hash:6].[ext]',
+            to: 'directory/[hash:6]/[name]-[contenthash:6].[ext]',
+          },
+        ],
+      })
+        .then(done)
+        .catch(done);
+    });
+
+    it('allows pattern to contain hash', (done) => {
+      runEmit({
+        expectedAssetKeys: ['directory/d41d8c.txt'],
+        patterns: [
+          {
+            from: 'directory/directoryfile.txt',
+            to: 'directory/[hash:6].txt',
           },
         ],
       })
@@ -1729,7 +1747,7 @@ describe('apply function', () => {
         .catch(done);
     });
 
-    it('can move multiple files to a non-root directory with name, hash and ext', (done) => {
+    it('can move multiple files to a non-root directory with name, contenthash and ext', (done) => {
       runEmit({
         expectedAssetKeys: [
           'nested/.dottedfile-79d39f',
@@ -1740,7 +1758,7 @@ describe('apply function', () => {
         patterns: [
           {
             from: 'directory',
-            to: 'nested/[path][name]-[hash:6].[ext]',
+            to: 'nested/[path][name]-[contenthash:6].[ext]',
           },
         ],
       })


### PR DESCRIPTION
BREAKING CHANGE: [hash] is treated as webpack (v4+) build hash. [contenthash] remains as expected.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Webpack distinguishes between hash and contenthash as explained here: https://github.com/webpack-contrib/copy-webpack-plugin/issues/349

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

This change breaks backwards compatibility with people using [hash], but actually mean [contenthash]. The library used to generate this ([loader-utils](https://www.npmjs.com/package/loader-utils)) 
only keeps [hash] for backwards compatibility themselves as described [here](https://github.com/webpack/loader-utils/blob/master/lib/interpolateName.js#L91).

### Additional Info
