### PR TITLE
fix: persist assets between rebuilds

### DIFF
--- a/src/postProcessPattern.js
+++ b/src/postProcessPattern.js
@@ -155,6 +155,16 @@ export default function postProcessPattern(globalRef, pattern, file) {
       .then((content) => {
         const hash = loaderUtils.getHashDigest(content);
 
+        // persist assets between rebuilds
+        compilation.assets[file.webpackTo] = {
+          size() {
+            return stats.size;
+          },
+          source() {
+            return content;
+          },
+        };
+
         if (
           !copyUnmodified &&
           written[file.webpackTo] &&
@@ -189,15 +199,6 @@ export default function postProcessPattern(globalRef, pattern, file) {
             file.absoluteFrom
           }'`
         );
-
-        compilation.assets[file.webpackTo] = {
-          size() {
-            return stats.size;
-          },
-          source() {
-            return content;
-          },
-        };
       });
   });
 }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Copied files are still part of the webpack assets between rebuilds.

After revamping [clean-webpack-plugin](https://github.com/johnagan/clean-webpack-plugin) to automatically remove unused webpack assets we've started getting reports of files being removed that were copied via this plugin. Since files copied are still part of webpack's assets, they should be persistent between rebuilds.

I am unsure how to write tests for this with your current test setup. If this is wanted, please point me in the right direction how to properly do this.

I think this also fixes #356 and possibly closes #309.

### Breaking Changes

I do not think this is a breaking change.

### Additional Info
