### PR TITLE
fix: use posix separators when adding assets to the compilation

### DIFF
--- a/src/postProcessPattern.js
+++ b/src/postProcessPattern.js
@@ -176,7 +176,11 @@ export default function postProcessPattern(globalRef, pattern, file) {
 
         written[file.webpackTo][file.absoluteFrom] = hash;
 
-        if (compilation.assets[file.webpackTo] && !file.force) {
+        // In Windows we should not set assets using \ seperators
+        // Because files will end up being set incorrecly when using the MemoryFileSystem system
+        const posixWebpackTo = file.webpackTo.replace(/\\/g, '/');
+
+        if (compilation.assets[posixWebpackTo] && !file.force) {
           logger.info(
             `skipping '${file.webpackTo}', because it already exists`
           );
@@ -190,7 +194,7 @@ export default function postProcessPattern(globalRef, pattern, file) {
           }'`
         );
 
-        compilation.assets[file.webpackTo] = {
+        compilation.assets[posixWebpackTo] = {
           size() {
             return stats.size;
           },

--- a/test/CopyPlugin.test.js
+++ b/test/CopyPlugin.test.js
@@ -163,10 +163,7 @@ describe('apply function', () => {
 
       if (opts.expectedAssetKeys && opts.expectedAssetKeys.length > 0) {
         expect(Object.keys(compilation.assets).sort()).toEqual(
-          opts.expectedAssetKeys
-            .sort()
-            .map(removeIllegalCharacterForWindows)
-            .map((item) => item.replace(/\//g, path.sep))
+          opts.expectedAssetKeys.sort().map(removeIllegalCharacterForWindows)
         );
       } else {
         expect(compilation.assets).toEqual({});
@@ -175,7 +172,7 @@ describe('apply function', () => {
       if (opts.expectedAssetContent) {
         // eslint-disable-next-line guard-for-in
         for (const key in opts.expectedAssetContent) {
-          const assetName = key.replace(/(\/|\\)/g, path.sep);
+          const assetName = key.replace(/\\/g, '/');
 
           expect(compilation.assets[assetName]).toBeDefined();
 
@@ -245,10 +242,7 @@ describe('apply function', () => {
       .then(() => {
         if (opts.expectedAssetKeys && opts.expectedAssetKeys.length > 0) {
           expect(Object.keys(compilation.assets).sort()).toEqual(
-            opts.expectedAssetKeys
-              .sort()
-              .map(removeIllegalCharacterForWindows)
-              .map((item) => item.replace(/\//g, path.sep))
+            opts.expectedAssetKeys.sort().map(removeIllegalCharacterForWindows)
           );
         } else {
           expect(compilation.assets).toEqual({});


### PR DESCRIPTION
What is happening is webpack's `MemoryFileSystem` will contain below entries

```
MemoryFileSystem {
  data:
   { _karma_webpack_:
      { '': true,
        'main.js':
         <Buffer 2f 2a 2a 2a 2a 2a 2a 2f 20 28 66 75 6e 63 74 69 6f 6e 28 6d 6f 64 75 6c 65 73 29 20 7b 20 2f 2f 20 77 65 62 70 61 63 6b 42 6f 6f 74 73 74 72 61 70 0a ... >,
        'polyfills.js':
         <Buffer 2f 2a 2a 2a 2a 2a 2a 2f 20 28 66 75 6e 63 74 69 6f 6e 28 6d 6f 64 75 6c 65 73 29 20 7b 20 2f 2f 20 77 65 62 70 61 63 6b 42 6f 6f 74 73 74 72 61 70 0a ... >,
        'polyfills-es5.js':
         <Buffer 2f 2a 2a 2a 2a 2a 2a 2f 20 28 66 75 6e 63 74 69 6f 6e 28 6d 6f 64 75 6c 65 73 29 20 7b 20 2f 2f 20 77 65 62 70 61 63 6b 42 6f 6f 74 73 74 72 61 70 0a ... >,
        'styles.js':
         <Buffer 2f 2a 2a 2a 2a 2a 2a 2f 20 28 66 75 6e 63 74 69 6f 6e 28 6d 6f 64 75 6c 65 73 29 20 7b 20 2f 2f 20 77 65 62 70 61 63 6b 42 6f 6f 74 73 74 72 61 70 0a ... >,
        'vendor.js':
         <Buffer 28 77 69 6e 64 6f 77 5b 22 77 65 62 70 61 63 6b 4a 73 6f 6e 70 22 5d 20 3d 20 77 69 6e 64 6f 77 5b 22 77 65 62 70 61 63 6b 4a 73 6f 6e 70 22 5d 20 7c ... >,
        'favicon.ico':
         <Buffer 00 00 01 00 02 00 10 10 00 00 00 00 20 00 68 04 00 00 26 00 00 00 20 20 00 00 00 00 20 00 a8 10 00 00 8e 04 00 00 28 00 00 00 10 00 00 00 20 00 00 00 ... >,
        assets: [Object],
        'assets\\test.json':
         <Buffer 7b 0d 0a 20 20 22 74 65 73 74 22 3a 20 74 72 75 65 0d 0a 7d 0d 0a> } } }
```

Instead of
```
MemoryFileSystem {
  data:
   { _karma_webpack_:
      { '': true,
        'main.js':
         <Buffer 2f 2a 2a 2a 2a 2a 2a 2f 20 28 66 75 6e 63 74 69 6f 6e 28 6d 6f 64 75 6c 65 73 29 20 7b 20 2f 2f 20 77 65 62 70 61 63 6b 42 6f 6f 74 73 74 72 61 70 0a ... >,
        'polyfills.js':
         <Buffer 2f 2a 2a 2a 2a 2a 2a 2f 20 28 66 75 6e 63 74 69 6f 6e 28 6d 6f 64 75 6c 65 73 29 20 7b 20 2f 2f 20 77 65 62 70 61 63 6b 42 6f 6f 74 73 74 72 61 70 0a ... >,
        'polyfills-es5.js':
         <Buffer 2f 2a 2a 2a 2a 2a 2a 2f 20 28 66 75 6e 63 74 69 6f 6e 28 6d 6f 64 75 6c 65 73 29 20 7b 20 2f 2f 20 77 65 62 70 61 63 6b 42 6f 6f 74 73 74 72 61 70 0a ... >,
        'styles.js':
         <Buffer 2f 2a 2a 2a 2a 2a 2a 2f 20 28 66 75 6e 63 74 69 6f 6e 28 6d 6f 64 75 6c 65 73 29 20 7b 20 2f 2f 20 77 65 62 70 61 63 6b 42 6f 6f 74 73 74 72 61 70 0a ... >,
        'vendor.js':
         <Buffer 28 77 69 6e 64 6f 77 5b 22 77 65 62 70 61 63 6b 4a 73 6f 6e 70 22 5d 20 3d 20 77 69 6e 64 6f 77 5b 22 77 65 62 70 61 63 6b 4a 73 6f 6e 70 22 5d 20 7c ... >,
        'favicon.ico':
         <Buffer 00 00 01 00 02 00 10 10 00 00 00 00 20 00 68 04 00 00 26 00 00 00 20 20 00 00 00 00 20 00 a8 10 00 00 8e 04 00 00 28 00 00 00 10 00 00 00 20 00 00 00 ... >,
        assets: [Object] } } }
```

When someone calls `context.fs.statSync('/_karma_webpack_/assets/test.json');` it will throw an error that the file cannot be found.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
