### PR TITLE
Performance improvement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,28 +98,20 @@ class CopyPlugin {
     compiler.hooks.afterEmit.tapAsync(plugin, (compilation, callback) => {
       logger.debug('starting after-emit');
 
-      // Add file dependencies if they're not already tracked
-      for (const fileDependency of fileDependencies) {
-        if (compilation.fileDependencies.has(fileDependency)) {
-          logger.debug(
-            `not adding '${fileDependency}' to change tracking, because it's already tracked`
-          );
-        } else {
-          logger.debug(`adding '${fileDependency}' to change tracking`);
-
+      // Add file dependencies
+      if ("addAll" in compilation.fileDependencies) {
+        compilation.fileDependencies.addAll(fileDependencies);
+      } else {
+        for (const fileDependency of fileDependencies) {
           compilation.fileDependencies.add(fileDependency);
         }
       }
 
-      // Add context dependencies if they're not already tracked
-      for (const contextDependency of contextDependencies) {
-        if (compilation.contextDependencies.has(contextDependency)) {
-          logger.debug(
-            `not adding '${contextDependency}' to change tracking, because it's already tracked`
-          );
-        } else {
-          logger.debug(`adding '${contextDependency}' to change tracking`);
-
+      // Add context dependencies
+      if ("addAll" in compilation.contextDependencies) {
+        compilation.contextDependencies.addAll(contextDependencies);
+      } else {
+        for (const contextDependency of contextDependencies) {
           compilation.contextDependencies.add(contextDependency);
         }
       }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**
- [x] **performance upgrade**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Sets don't allow duplicates, so checking for `has` is not necessary

webpack 5 makes these Sets lazy, which makes reading more expensive.
So only the watcher should read from these Sets, which is called after the compilation has finished,
so that doesn't contribute to build performance.

LazySets also have a `addAll` method, which allows to add an Iterable lazily (only iterated when LazySet is read)
### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

No, webpack 4 compatibility is kept

### Additional Info
