### PR TITLE
chore: added webpack logger and dep audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1860,11 +1860,6 @@
         "string-width": "^2.0.0"
       }
     },
-    "ansi-colors": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
-    },
     "ansi-escapes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
@@ -11886,7 +11881,8 @@
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -12013,15 +12009,6 @@
             "readable-stream": "^2.0.1"
           }
         }
-      }
-    },
-    "webpack-log": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
-      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
-      "requires": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
       }
     },
     "webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "normalize-path": "^3.0.0",
     "p-limit": "^2.2.1",
     "schema-utils": "^1.0.0",
-    "serialize-javascript": "^2.1.2",
-    "webpack-log": "^2.0.0"
+    "serialize-javascript": "^2.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import path from 'path';
 
 import validateOptions from 'schema-utils';
-import logging from 'webpack/lib/logging/runtime';
 
 import schema from './options.json';
 import preProcessPattern from './preProcessPattern';
@@ -31,14 +30,9 @@ class CopyPlugin {
       ({ context } = this.options);
     }
 
-    logging.configureDefaultLogger({
-      level: this.options.logLevel || 'warn',
-    });
-
     const plugin = { name: 'CopyPlugin' };
-
     compiler.hooks.emit.tapAsync(plugin, (compilation, callback) => {
-      const logger = logging.getLogger(plugin.name);
+      const logger = compiler.getInfrastructureLogger(plugin.name);
 
       const globalRef = {
         logger,
@@ -96,7 +90,7 @@ class CopyPlugin {
     });
 
     compiler.hooks.afterEmit.tapAsync(plugin, (compilation, callback) => {
-      const logger = logging.getLogger(plugin.name);
+      const logger = compiler.getInfrastructureLogger(plugin.name);
 
       // Add file dependencies
       if ('addAll' in compilation.fileDependencies) {

--- a/src/index.js
+++ b/src/index.js
@@ -31,9 +31,10 @@ class CopyPlugin {
     }
 
     const plugin = { name: 'CopyPlugin' };
-    compiler.hooks.emit.tapAsync(plugin, (compilation, callback) => {
-      const logger = compiler.getInfrastructureLogger(plugin.name);
 
+    const logger = compiler.getInfrastructureLogger(plugin.name);
+
+    compiler.hooks.emit.tapAsync(plugin, (compilation, callback) => {
       const globalRef = {
         logger,
         compilation,
@@ -90,8 +91,6 @@ class CopyPlugin {
     });
 
     compiler.hooks.afterEmit.tapAsync(plugin, (compilation, callback) => {
-      const logger = compiler.getInfrastructureLogger(plugin.name);
-
       // Add file dependencies
       if ('addAll' in compilation.fileDependencies) {
         compilation.fileDependencies.addAll(fileDependencies);

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import validateOptions from 'schema-utils';
-import log from 'webpack-log';
+import logging from 'webpack/lib/logging/runtime';
 
 import schema from './options.json';
 import preProcessPattern from './preProcessPattern';
@@ -31,15 +31,14 @@ class CopyPlugin {
       ({ context } = this.options);
     }
 
-    const logger = log({
-      name: 'copy-webpack-plugin',
+    logging.configureDefaultLogger({
       level: this.options.logLevel || 'warn',
     });
 
     const plugin = { name: 'CopyPlugin' };
 
     compiler.hooks.emit.tapAsync(plugin, (compilation, callback) => {
-      logger.debug('starting emit');
+      const logger = logging.getLogger(plugin.name);
 
       const globalRef = {
         logger,
@@ -97,7 +96,7 @@ class CopyPlugin {
     });
 
     compiler.hooks.afterEmit.tapAsync(plugin, (compilation, callback) => {
-      logger.debug('starting after-emit');
+      const logger = logging.getLogger(plugin.name);
 
       // Add file dependencies
       if ('addAll' in compilation.fileDependencies) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [X] **metadata update**

### Motivation / Use-Case

Webpack-log is depreciated.
Added the webpack logger provided by the webpack in `compilation` object

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

No.
Just that webpack's logger is available from `4.39` so, I guess need to add prev version compatibility.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
NA