### PR TITLE
add concurrency control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [5.1.2](https://github.com/webpack-contrib/copy-webpack-plugin/compare/v5.1.1...v5.1.2) (2019-12-15)
+### [5.1.2](https://github.com/webpack-contrib/copy-webpack-plugin/compare/v5.1.1...v5.1.2) (2019-12-17)
 
+
+### Features
+
+* add concurrency control
 
 ### Bug Fixes
 
-* fix error:too many open files
+* fix error: too many open files
 
 ### [5.1.1](https://github.com/webpack-contrib/copy-webpack-plugin/compare/v5.1.0...v5.1.1) (2019-12-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [5.1.2](https://github.com/webpack-contrib/copy-webpack-plugin/compare/v5.1.1...v5.1.2) (2019-12-15)
 
+
+### Bug Fixes
+
+* fix error:too many open files
+
 ### [5.1.1](https://github.com/webpack-contrib/copy-webpack-plugin/compare/v5.1.0...v5.1.1) (2019-12-12)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.1.2](https://github.com/webpack-contrib/copy-webpack-plugin/compare/v5.1.1...v5.1.2) (2019-12-15)
+
 ### [5.1.1](https://github.com/webpack-contrib/copy-webpack-plugin/compare/v5.1.0...v5.1.1) (2019-12-12)
 
 

--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ module.exports = {
 |         [`ignore`](#ignore)         |  `{Array}`  |            `[]`            | Array of globs to ignore (applied to `from`)                                                                                                      |
 |        [`context`](#context)        | `{String}`  | `compiler.options.context` | A path that determines how to interpret the `from` path, shared for all patterns                                                                  |
 | [`copyUnmodified`](#copyunmodified) | `{Boolean}` |          `false`           | Copies files, regardless of modification when using watch or `webpack-dev-server`. All files are copied on first build, regardless of this option |
+|    [`concurrency`](#concurrency)    | `{Number}`  |         `Infinity`         | Limit fs concurrency                                                                                                                              |
 
 #### `logLevel`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "copy-webpack-plugin",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copy-webpack-plugin",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Copy files && directories with webpack",
   "license": "MIT",
   "repository": "webpack-contrib/copy-webpack-plugin",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import path from 'path';
 
 import validateOptions from 'schema-utils';
 import log from 'webpack-log';
+import pLimit from 'p-limit';
 
 import schema from './options.json';
 import preProcessPattern from './preProcessPattern';
@@ -77,10 +78,14 @@ class CopyPlugin {
                   return Promise.resolve();
                 }
 
+                const limit = pLimit(globalRef.concurrency || Infinity);
+
                 return Promise.all(
                   files
                     .filter(Boolean)
-                    .map((file) => postProcessPattern(globalRef, pattern, file))
+                    .map((file) =>
+                      limit(() => postProcessPattern(globalRef, pattern, file))
+                    )
                 );
               })
             )

--- a/src/processPattern.js
+++ b/src/processPattern.js
@@ -22,7 +22,7 @@ export default function processPattern(globalRef, pattern) {
     return Promise.resolve();
   }
 
-  const limit = pLimit(concurrency || 100);
+  const limit = pLimit(concurrency || Infinity);
 
   logger.info(
     `begin globbing '${pattern.glob}' with a context of '${pattern.context}'`

--- a/src/processPattern.js
+++ b/src/processPattern.js
@@ -22,7 +22,7 @@ export default function processPattern(globalRef, pattern) {
     return Promise.resolve();
   }
 
-  const limit = pLimit(concurrency || Infinity);
+  const limit = pLimit(concurrency || 100);
 
   logger.info(
     `begin globbing '${pattern.glob}' with a context of '${pattern.context}'`


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [x] new **feature**

### Motivation / Use-Case

Before modification, when too many files are copied, such as more than 20,000 files, "Error: EMFILE: too many open files, open.." will be generated. Even though I used 'graceful-fs', this error occurred when I had many other applications open on my computer, so I made a modification to limit the concurrency of fs, which was tested with no problem on Windows or Linux.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
