### PR TITLE
"Keep times" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ module.exports = {
 |         [`ignore`](#ignore)         |  `{Array}`  |            `[]`            | Array of globs to ignore (applied to `from`)                                                                                                      |
 |        [`context`](#context)        | `{String}`  | `compiler.options.context` | A path that determines how to interpret the `from` path, shared for all patterns                                                                  |
 | [`copyUnmodified`](#copyunmodified) | `{Boolean}` |          `false`           | Copies files, regardless of modification when using watch or `webpack-dev-server`. All files are copied on first build, regardless of this option |
+|      [`keepTimes`](#keeptimes)      | `{Boolean}` |          `false`           | Copy the original access and modification over to the destination files, when possible                                                            |
 
 #### `logLevel`
 
@@ -565,6 +566,18 @@ Copies files, regardless of modification when using watch or `webpack-dev-server
 ```js
 module.exports = {
   plugins: [new CopyPlugin([...patterns], { copyUnmodified: true })],
+};
+```
+
+#### `keepTimes`
+
+Attempt to copy source files' access and modification times over to the destination files.
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  plugins: [new CopyPlugin([...patterns], { keepTimes: true })],
 };
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import schema from './options.json';
 import preProcessPattern from './preProcessPattern';
 import processPattern from './processPattern';
 import postProcessPattern from './postProcessPattern';
+import updateTimes from './updateTimes';
 
 class CopyPlugin {
   constructor(patterns = [], options = {}) {
@@ -52,6 +53,7 @@ class CopyPlugin {
         output: compiler.options.output.path,
         ignore: this.options.ignore || [],
         copyUnmodified: this.options.copyUnmodified,
+        keepTimes: this.options.keepTimes,
         concurrency: this.options.concurrency,
       };
 
@@ -115,6 +117,10 @@ class CopyPlugin {
         for (const contextDependency of contextDependencies) {
           compilation.contextDependencies.add(contextDependency);
         }
+      }
+
+      if (this.options.keepTimes) {
+        updateTimes(compiler, compilation, logger);
       }
 
       logger.debug('finishing after-emit');

--- a/src/options.json
+++ b/src/options.json
@@ -67,6 +67,9 @@
         },
         "transformPath": {
           "instanceof": "Function"
+        },
+        "keepTimes": {
+          "type": "boolean"
         }
       },
       "required": ["from"]

--- a/src/postProcessPattern.js
+++ b/src/postProcessPattern.js
@@ -197,6 +197,10 @@ export default function postProcessPattern(globalRef, pattern, file) {
           source() {
             return content;
           },
+          copyPluginTimes: {
+            atime: stats.atime,
+            mtime: stats.mtime,
+          },
         };
       });
   });

--- a/src/updateTimes.js
+++ b/src/updateTimes.js
@@ -1,0 +1,58 @@
+/**
+ * Attempt to get an Utimes function for the compiler's output filesystem.
+ */
+function getUtimesFunction(compiler) {
+  if (compiler.outputFileSystem.utimes) {
+    // Webpack 5+ on Node will use graceful-fs for outputFileSystem so utimes is always there.
+    // Other custom outputFileSystems could also have utimes.
+    return compiler.outputFileSystem.utimes.bind(compiler.outputFileSystem);
+  } else if (
+    compiler.outputFileSystem.constructor &&
+    compiler.outputFileSystem.constructor.name === 'NodeOutputFileSystem'
+  ) {
+    // Default NodeOutputFileSystem can just use fs.utimes, but we need to late-import it in case
+    // we're running in a web context and statically importing `fs` might be a bad idea.
+    // eslint-disable-next-line global-require
+    return require('fs').utimes;
+  }
+  return null;
+}
+
+/**
+ * Update the times of disk files for which we have recorded a source time
+ * @param compiler
+ * @param compilation
+ * @param logger
+ */
+function updateTimes(compiler, compilation, logger) {
+  const utimes = getUtimesFunction(compiler);
+  let nUpdated = 0;
+  for (const name of Object.keys(compilation.assets)) {
+    const asset = compilation.assets[name];
+    // eslint-disable-next-line no-underscore-dangle
+    const times = asset.copyPluginTimes;
+    if (times) {
+      const targetPath =
+        asset.existsAt ||
+        compiler.outputFileSystem.join(compiler.outputPath, name);
+      if (!utimes) {
+        logger.warn(
+          `unable to update time for ${targetPath} using current file system`
+        );
+      } else {
+        // TODO: process these errors in a better way and/or wait for completion?
+        utimes(targetPath, times.atime, times.mtime, (err) => {
+          if (err) {
+            logger.warn(`${targetPath}: utimes: ${err}`);
+          }
+        });
+        nUpdated += 1;
+      }
+    }
+  }
+  if (nUpdated > 0) {
+    logger.info(`times updated for ${nUpdated} copied files`);
+  }
+}
+
+export default updateTimes;


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This adds the "keep file times" functionality discussed in #396.

### Breaking Changes

This functionality is opt-in, so nothing should break (except maybe if this plugin is used in a web context without a shim for `fs`, see below).

### Additional Info

The code in `updateTimes` is a little finicky since we need to find an implementation of `utimes` to use. When run in a web context (or with an output file system we don't support), turning `keepTimes` on will just result in a bunch of warnings.

According to https://github.com/webpack/webpack/commit/e9c0d068ddbb3213e7601138c5403598da6ac779 the default output filesystem in the forthcoming Webpack 5 will just be `graceful-fs`, which has `utimes` natively. If the output filesystem object has `utimes`, we expect it to be a function that smells like `fs.utimes()`. (This will work for any custom filesystem object too.)

For Webpack 4, however, the default output file system in Webpack 4 is a custom `NodeOutputFileSystem` which lacks `utimes` altogether. However, since it is [a simple wrapper around `fs`](https://github.com/webpack/webpack/blob/5f65ecbf1999ebe82259927289073a285b0e8a6c/lib/node/NodeOutputFileSystem.js), we can assume that `fs.utimes()` works fine for assets output with it.