### PR TITLE
Validate global options too

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ Default: `[]`
 
 Globs to ignore files.
 
+May also contain Minimatch setting objects (e.g. `{dot: true, matchBase: true}`).
+
 **webpack.config.js**
 
 ```js
@@ -533,6 +535,8 @@ module.exports = {
 #### `ignore`
 
 Array of globs to ignore (applied to `from`).
+
+Like per-pattern ignores, may also contain Minimatch setting objects.
 
 **webpack.config.js**
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,16 @@ import path from 'path';
 import validateOptions from 'schema-utils';
 import log from 'webpack-log';
 
-import schema from './options.json';
+import patternsSchema from './patterns.json';
+import optionsSchema from './options.json';
 import preProcessPattern from './preProcessPattern';
 import processPattern from './processPattern';
 import postProcessPattern from './postProcessPattern';
 
 class CopyPlugin {
   constructor(patterns = [], options = {}) {
-    validateOptions(schema, patterns, this.constructor.name);
+    validateOptions(patternsSchema, patterns, this.constructor.name);
+    validateOptions(optionsSchema, options, this.constructor.name);
 
     this.patterns = patterns;
     this.options = options;

--- a/src/options.json
+++ b/src/options.json
@@ -1,90 +1,33 @@
 {
-  "definitions": {
-    "ObjectPattern": {
-      "type": "object",
-      "properties": {
-        "from": {
-          "anyOf": [
-            {
-              "type": "string",
-              "minLength": 1
-            },
-            {
-              "type": "object"
-            }
-          ]
-        },
-        "to": {
-          "type": "string"
-        },
-        "context": {
-          "type": "string"
-        },
-        "toType": {
-          "enum": ["dir", "file", "template"]
-        },
-        "test": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "instanceof": "RegExp"
-            }
-          ]
-        },
-        "force": {
-          "type": "boolean"
-        },
-        "ignore": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "object"
-              }
-            ]
-          }
-        },
-        "flatten": {
-          "type": "boolean"
-        },
-        "cache": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "object"
-            }
-          ]
-        },
-        "transform": {
-          "instanceof": "Function"
-        },
-        "transformPath": {
-          "instanceof": "Function"
-        }
-      },
-      "required": ["from"]
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "logLevel": {
+      "description": "Level of messages that the module will log",
+      "enum": ["trace", "debug", "info", "warn", "error", "silent"]
     },
-    "StringPattern": {
-      "type": "string",
-      "minLength": 1
+    "ignore": {
+      "description": "Array of globs to ignore (applied to `from`)",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "context": {
+      "description": "A path that determines how to interpret the `from` path, shared for all patterns",
+      "type": "string"
+    },
+    "copyUnmodified": {
+      "description": "Copies files, regardless of modification, when using watchers",
+      "type": "boolean"
     }
   },
-  "type": "array",
-  "items": {
-    "anyOf": [
-      {
-        "$ref": "#/definitions/StringPattern"
-      },
-      {
-        "$ref": "#/definitions/ObjectPattern"
-      }
-    ]
-  }
+  "title": "Options"
 }

--- a/src/patterns.json
+++ b/src/patterns.json
@@ -1,0 +1,90 @@
+{
+  "definitions": {
+    "ObjectPattern": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "to": {
+          "type": "string"
+        },
+        "context": {
+          "type": "string"
+        },
+        "toType": {
+          "enum": ["dir", "file", "template"]
+        },
+        "test": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "instanceof": "RegExp"
+            }
+          ]
+        },
+        "force": {
+          "type": "boolean"
+        },
+        "ignore": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "flatten": {
+          "type": "boolean"
+        },
+        "cache": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "transform": {
+          "instanceof": "Function"
+        },
+        "transformPath": {
+          "instanceof": "Function"
+        }
+      },
+      "required": ["from"]
+    },
+    "StringPattern": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "type": "array",
+  "items": {
+    "anyOf": [
+      {
+        "$ref": "#/definitions/StringPattern"
+      },
+      {
+        "$ref": "#/definitions/ObjectPattern"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I noticed #419 added validation for the `patterns` array, but the global options (which are touched by e.g. #435) aren't validated. (I may or may not have banged my head against the wall there.)

The documentation was also updated to reflect the fact that one can actually pass in Minimatch settings objects for ignore too.

### Breaking Changes

This may break some downstream software misusing the `options` object.

### Additional Info

"Test update" is not checked, because tests don't pass in naughty options.