### PR TITLE
feat: migrate on webpack built-in logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,34 +501,9 @@ module.exports = {
 
 |                Name                 |    Type     |          Default           | Description                                                                                                                                       |
 | :---------------------------------: | :---------: | :------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------ |
-|       [`logLevel`](#loglevel)       | `{String}`  |        **`'warn'`**        | Level of messages that the module will log                                                                                                        |
 |         [`ignore`](#ignore)         |  `{Array}`  |            `[]`            | Array of globs to ignore (applied to `from`)                                                                                                      |
 |        [`context`](#context)        | `{String}`  | `compiler.options.context` | A path that determines how to interpret the `from` path, shared for all patterns                                                                  |
 | [`copyUnmodified`](#copyunmodified) | `{Boolean}` |          `false`           | Copies files, regardless of modification when using watch or `webpack-dev-server`. All files are copied on first build, regardless of this option |
-
-#### `logLevel`
-
-This property defines the level of messages that the module will log. Valid levels include:
-
-- `trace`
-- `debug`
-- `info`
-- `warn` (default)
-- `error`
-- `silent`
-
-Setting a log level means that all other levels below it will be visible in the
-console. Setting `logLevel: 'silent'` will hide all console output. The module
-leverages [`webpack-log`](https://github.com/webpack-contrib/webpack-log#readme)
-for logging management, and more information can be found on its page.
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  plugins: [new CopyPlugin([...patterns], { logLevel: 'debug' })],
-};
-```
 
 #### `ignore`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,11 +2420,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
     },
-    "ansi-colors": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
-    },
     "ansi-escapes": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -13516,7 +13511,8 @@
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -13713,15 +13709,6 @@
             "ajv-keywords": "^3.1.0"
           }
         }
-      }
-    },
-    "webpack-log": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
-      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
-      "requires": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
       }
     },
     "webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "webpack": "^4.0.0 || ^5.0.0"
+    "webpack": "^4.37.0 || ^5.0.0"
   },
   "dependencies": {
     "cacache": "^15.0.0",
@@ -51,8 +51,7 @@
     "normalize-path": "^3.0.0",
     "p-limit": "^2.3.0",
     "schema-utils": "^2.6.6",
-    "serialize-javascript": "^3.0.0",
-    "webpack-log": "^2.0.0"
+    "serialize-javascript": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import path from 'path';
 
 import validateOptions from 'schema-utils';
-import log from 'webpack-log';
 
 import schema from './options.json';
 import preProcessPattern from './preProcessPattern';
@@ -35,10 +34,7 @@ class CopyPlugin {
       ({ context } = this.options);
     }
 
-    const logger = log({
-      name: 'copy-webpack-plugin',
-      level: this.options.logLevel || 'warn',
-    });
+    const logger = compiler.getInfrastructureLogger('copy-webpack-plugin');
 
     const plugin = { name: 'CopyPlugin' };
 

--- a/src/postProcessPattern.js
+++ b/src/postProcessPattern.js
@@ -50,7 +50,7 @@ export default function postProcessPattern(globalRef, pattern, file) {
     return readFile(inputFileSystem, file.absoluteFrom)
       .then((content) => {
         if (pattern.transform) {
-          logger.info(`transforming content for '${file.absoluteFrom}'`);
+          logger.log(`transforming content for '${file.absoluteFrom}'`);
 
           // eslint-disable-next-line no-shadow
           const transform = (content, absoluteFrom) =>
@@ -102,7 +102,7 @@ export default function postProcessPattern(globalRef, pattern, file) {
       })
       .then((content) => {
         if (pattern.toType === 'template') {
-          logger.info(
+          logger.log(
             `interpolating template '${file.webpackTo}' for '${file.relativeFrom}'`
           );
 
@@ -130,7 +130,7 @@ export default function postProcessPattern(globalRef, pattern, file) {
       })
       .then((content) => {
         if (pattern.transformPath) {
-          logger.info(
+          logger.log(
             `transforming path '${file.webpackTo}' for '${file.absoluteFrom}'`
           );
 
@@ -158,7 +158,7 @@ export default function postProcessPattern(globalRef, pattern, file) {
           written[targetPath][targetAbsolutePath] &&
           written[targetPath][targetAbsolutePath] === hash
         ) {
-          logger.info(
+          logger.log(
             `skipping '${file.webpackTo}', because content hasn't changed`
           );
 
@@ -174,14 +174,12 @@ export default function postProcessPattern(globalRef, pattern, file) {
         written[targetPath][targetAbsolutePath] = hash;
 
         if (compilation.assets[targetPath] && !file.force) {
-          logger.info(
-            `skipping '${file.webpackTo}', because it already exists`
-          );
+          logger.log(`skipping '${file.webpackTo}', because it already exists`);
 
           return;
         }
 
-        logger.info(
+        logger.log(
           `writing '${file.webpackTo}' to compilation assets from '${file.absoluteFrom}'`
         );
 

--- a/src/processPattern.js
+++ b/src/processPattern.js
@@ -24,7 +24,7 @@ export default function processPattern(globalRef, pattern) {
 
   const limit = pLimit(concurrency || 100);
 
-  logger.info(
+  logger.log(
     `begin globbing '${pattern.glob}' with a context of '${pattern.context}'`
   );
 
@@ -76,7 +76,7 @@ export default function processPattern(globalRef, pattern) {
             logger.debug(`testing ${glob} against ${file.relativeFrom}`);
 
             if (minimatch(file.relativeFrom, glob, globParams)) {
-              logger.info(
+              logger.log(
                 `ignoring '${file.relativeFrom}', because it matches the ignore glob '${glob}'`
               );
 
@@ -109,7 +109,7 @@ export default function processPattern(globalRef, pattern) {
             file.webpackTo = path.relative(output, file.webpackTo);
           }
 
-          logger.info(
+          logger.log(
             `determined that '${from}' should write to '${file.webpackTo}'`
           );
 

--- a/test/helpers/mocks.js
+++ b/test/helpers/mocks.js
@@ -21,6 +21,14 @@ class MockCompiler {
       };
     }
 
+    this.getInfrastructureLogger = () => ({
+      error() {},
+      warn() {},
+      info() {},
+      log() {},
+      debug() {},
+    });
+
     this.inputFileSystem = new CachedInputFileSystem(
       new NodeJsInputFileSystem(),
       0


### PR DESCRIPTION
BREAKING CHANGE: the `logLever` was removed in favor the `infrastructureLogging.level` option, please read the [documentation](https://webpack.js.org/configuration/other-options/#infrastructurelogginglevel)

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Migrate on built-in webpack logger

### Breaking Changes

Yes

### Additional Info


We will add more tests before release