### PR TITLE
refactor: remove legacy hacks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,14 +55,6 @@ class CopyPlugin {
         concurrency: this.options.concurrency,
       };
 
-      if (
-        globalRef.output === '/' &&
-        compiler.options.devServer &&
-        compiler.options.devServer.outputPath
-      ) {
-        globalRef.output = compiler.options.devServer.outputPath;
-      }
-
       const { patterns } = this;
 
       Promise.all(

--- a/src/processPattern.js
+++ b/src/processPattern.js
@@ -7,7 +7,7 @@ import minimatch from 'minimatch';
 import isObject from './utils/isObject';
 
 export default function processPattern(globalRef, pattern) {
-  const { logger, output, concurrency, compilation } = globalRef;
+  const { logger, output, concurrency } = globalRef;
   const globOptions = Object.assign(
     {
       cwd: pattern.context,
@@ -97,15 +97,6 @@ export default function processPattern(globalRef, pattern) {
           }
 
           if (path.isAbsolute(file.webpackTo)) {
-            if (output === '/') {
-              const message =
-                'using older versions of webpack-dev-server, devServer.outputPath must be defined to write to absolute paths';
-
-              logger.error(message);
-
-              compilation.errors.push(new Error(message));
-            }
-
             file.webpackTo = path.relative(output, file.webpackTo);
           }
 

--- a/test/CopyPlugin.test.js
+++ b/test/CopyPlugin.test.js
@@ -1,9 +1,7 @@
 import path from 'path';
 
-import { MockCompiler } from './helpers/mocks';
 import { run, runEmit, runChange } from './helpers/run';
 
-const BUILD_DIR = path.join(__dirname, 'build');
 const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
 describe('apply function', () => {
@@ -302,50 +300,6 @@ describe('apply function', () => {
         patterns: [
           {
             from: '!(directory)\\**\\*.txt',
-          },
-        ],
-      })
-        .then(done)
-        .catch(done);
-    });
-  });
-
-  describe('dev server', () => {
-    it('should work with absolute to if outpath is defined with webpack-dev-server', (done) => {
-      runEmit({
-        compiler: new MockCompiler({
-          outputPath: '/',
-          devServer: {
-            outputPath: BUILD_DIR,
-          },
-        }),
-        expectedAssetKeys: ['file.txt'],
-        patterns: [
-          {
-            from: 'file.txt',
-            to: BUILD_DIR,
-          },
-        ],
-      })
-        .then(done)
-        .catch(done);
-    });
-
-    it("should throw an error when output path isn't defined with webpack-dev-server", (done) => {
-      runEmit({
-        compiler: new MockCompiler({
-          outputPath: '/',
-        }),
-        skipAssetsTesting: true,
-        expectedErrors: [
-          new Error(
-            'using older versions of webpack-dev-server, devServer.outputPath must be defined to write to absolute paths'
-          ),
-        ],
-        patterns: [
-          {
-            from: 'file.txt',
-            to: BUILD_DIR,
           },
         ],
       })


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Remove old hacks

### Breaking Changes

Yes

BREAKING CHANGE: the `2` version of `webpack-dev-server` is not supported anymore

### Additional Info

No