### PR TITLE
refactor: rename the `cache` option to `cacheTransform`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,20 @@ module.exports = {
 
 ### Patterns
 
-|               Name                |        Type         |                     Default                     | Description                                                                                           |
-| :-------------------------------: | :-----------------: | :---------------------------------------------: | :---------------------------------------------------------------------------------------------------- |
-|          [`from`](#from)          |     `{String}`      |                   `undefined`                   | Glob or path from where we сopy files.                                                                |
-|            [`to`](#to)            |     `{String}`      |            `compiler.options.output`            | Output path.                                                                                          |
-|       [`context`](#context)       |     `{String}`      | `options.context \|\| compiler.options.context` | A path that determines how to interpret the `from` path.                                              |
-|        [`toType`](#totype)        |     `{String}`      |                   `undefined`                   | Determinate what is `to` option - directory, file or template.                                        |
-|          [`test`](#test)          | `{String\|RegExp}`  |                   `undefined`                   | Pattern for extracting elements to be used in `to` templates.                                         |
-|         [`force`](#force)         |     `{Boolean}`     |                     `false`                     | Overwrites files already in `compilation.assets` (usually added by other plugins/loaders).            |
-|        [`ignore`](#ignore)        |      `{Array}`      |                      `[]`                       | Globs to ignore files.                                                                                |
-|       [`flatten`](#flatten)       |     `{Boolean}`     |                     `false`                     | Removes all directory references and only copies file names.                                          |
-|         [`cache`](#cache)         | `{Boolean\|Object}` |                     `false`                     | Enable `transform` caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache. |
-|     [`transform`](#transform)     |    `{Function}`     |                   `undefined`                   | Allows to modify the file contents.                                                                   |
-| [`transformPath`](#transformpath) |    `{Function}`     |                   `undefined`                   | Allows to modify the writing path.                                                                    |
-|   [`globOptions`](#globoptions)   |     `{Object}`      |                   `undefined`                   | [Options][glob-options] passed to the glob pattern matching library                                   |
+|                Name                 |        Type         |                     Default                     | Description                                                                                           |
+| :---------------------------------: | :-----------------: | :---------------------------------------------: | :---------------------------------------------------------------------------------------------------- |
+|           [`from`](#from)           |     `{String}`      |                   `undefined`                   | Glob or path from where we сopy files.                                                                |
+|             [`to`](#to)             |     `{String}`      |            `compiler.options.output`            | Output path.                                                                                          |
+|        [`context`](#context)        |     `{String}`      | `options.context \|\| compiler.options.context` | A path that determines how to interpret the `from` path.                                              |
+|    [`globOptions`](#globoptions)    |     `{Object}`      |                   `undefined`                   | [Options][glob-options] passed to the glob pattern matching library                                   |
+|         [`toType`](#totype)         |     `{String}`      |                   `undefined`                   | Determinate what is `to` option - directory, file or template.                                        |
+|           [`test`](#test)           | `{String\|RegExp}`  |                   `undefined`                   | Pattern for extracting elements to be used in `to` templates.                                         |
+|          [`force`](#force)          |     `{Boolean}`     |                     `false`                     | Overwrites files already in `compilation.assets` (usually added by other plugins/loaders).            |
+|         [`ignore`](#ignore)         |      `{Array}`      |                      `[]`                       | Globs to ignore files.                                                                                |
+|        [`flatten`](#flatten)        |     `{Boolean}`     |                     `false`                     | Removes all directory references and only copies file names.                                          |
+|      [`transform`](#transform)      |    `{Function}`     |                   `undefined`                   | Allows to modify the file contents.                                                                   |
+| [`cacheTransform`](#cacheTransform) | `{Boolean\|Object}` |                     `false`                     | Enable `transform` caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache. |
+|  [`transformPath`](#transformpath)  |    `{Function}`     |                   `undefined`                   | Allows to modify the writing path.                                                                    |
 
 #### `from`
 
@@ -180,6 +180,33 @@ module.exports = {
           from: 'src/*.txt',
           to: 'dest/',
           context: 'app/',
+        },
+      ],
+    }),
+  ],
+};
+```
+
+#### `globOptions`
+
+Type: `Object`
+Default: `undefined`
+
+Allows to configute the glob pattern matching library used by the plugin. [See the list of supported options][glob-options]
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        {
+          from: 'public/**/*',
+          globOptions: {
+            dot: true,
+            gitignore: true,
+          },
         },
       ],
     }),
@@ -391,35 +418,6 @@ module.exports = {
 };
 ```
 
-#### `cache`
-
-Type: `Boolean|Object`
-Default: `false`
-
-Enable/disable `transform` caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache.
-Default path to cache directory: `node_modules/.cache/copy-webpack-plugin`.
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  plugins: [
-    new CopyPlugin({
-      patterns: [
-        {
-          from: 'src/*.png',
-          to: 'dest/',
-          transform(content, path) {
-            return optimize(content);
-          },
-          cache: true,
-        },
-      ],
-    }),
-  ],
-};
-```
-
 #### `transform`
 
 Type: `Function`
@@ -460,6 +458,35 @@ module.exports = {
           transform(content, path) {
             return Promise.resolve(optimize(content));
           },
+        },
+      ],
+    }),
+  ],
+};
+```
+
+#### `cacheTransform`
+
+Type: `Boolean|Object`
+Default: `false`
+
+Enable/disable `transform` caching. You can use `{ cacheTransform: { key: 'my-cache-key' } }` to invalidate the cache.
+Default path to cache directory: `node_modules/.cache/copy-webpack-plugin`.
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        {
+          from: 'src/*.png',
+          to: 'dest/',
+          transform(content, path) {
+            return optimize(content);
+          },
+          cacheTransform: true,
         },
       ],
     }),
@@ -510,33 +537,6 @@ module.exports = {
           to: 'dest/',
           transformPath(targetPath, absolutePath) {
             return Promise.resolve('newPath');
-          },
-        },
-      ],
-    }),
-  ],
-};
-```
-
-#### `globOptions`
-
-Type: `Object`
-Default: `undefined`
-
-Allows to configute the glob pattern matching library used by the plugin. [See the list of supported options][glob-options]
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  plugins: [
-    new CopyPlugin({
-      patterns: [
-        {
-          from: 'public/**/*',
-          globOptions: {
-            dot: true,
-            gitignore: true,
           },
         },
       ],

--- a/src/options.json
+++ b/src/options.json
@@ -45,7 +45,10 @@
         "flatten": {
           "type": "boolean"
         },
-        "cache": {
+        "transform": {
+          "instanceof": "Function"
+        },
+        "cacheTransform": {
           "anyOf": [
             {
               "type": "boolean"
@@ -54,9 +57,6 @@
               "type": "object"
             }
           ]
-        },
-        "transform": {
-          "instanceof": "Function"
         },
         "transformPath": {
           "instanceof": "Function"

--- a/src/postProcessPattern.js
+++ b/src/postProcessPattern.js
@@ -49,14 +49,14 @@ export default function postProcessPattern(globalRef, pattern, file) {
           const transform = (content, absoluteFrom) =>
             pattern.transform(content, absoluteFrom);
 
-          if (pattern.cache) {
+          if (pattern.cacheTransform) {
             if (!globalRef.cacheDir) {
               globalRef.cacheDir =
                 findCacheDir({ name: 'copy-webpack-plugin' }) || os.tmpdir();
             }
 
-            const cacheKey = pattern.cache.key
-              ? pattern.cache.key
+            const cacheKey = pattern.cacheTransform.key
+              ? pattern.cacheTransform.key
               : serialize({
                   name,
                   version,

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -14,7 +14,7 @@ exports[`validate options should throw an error on the "options" option with "{"
 exports[`validate options should throw an error on the "patterns" option with "" value 1`] = `
 "Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
  - options.patterns should be an array:
-   [non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, cache?, transform?, transformPath?, … }, ...] (should not have fewer than 1 item)"
+   [non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, transform?, cacheTransform?, transformPath?, … }, ...] (should not have fewer than 1 item)"
 `;
 
 exports[`validate options should throw an error on the "patterns" option with "[""]" value 1`] = `
@@ -45,7 +45,7 @@ exports[`validate options should throw an error on the "patterns" option with "[
 exports[`validate options should throw an error on the "patterns" option with "[{"from":"test.txt","to":"dir","context":"context","ignore":["test.txt",true]}]" value 1`] = `
 "Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
  - options.patterns[0] should be one of these:
-   non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, cache?, transform?, transformPath?, … }
+   non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, transform?, cacheTransform?, transformPath?, … }
    Details:
     * options.patterns[0].ignore[1] should be one of these:
       string | object { … }
@@ -58,7 +58,7 @@ exports[`validate options should throw an error on the "patterns" option with "[
 exports[`validate options should throw an error on the "patterns" option with "[{"from":"test.txt","to":"dir","context":"context","ignore":[true]}]" value 1`] = `
 "Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
  - options.patterns[0] should be one of these:
-   non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, cache?, transform?, transformPath?, … }
+   non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, transform?, cacheTransform?, transformPath?, … }
    Details:
     * options.patterns[0].ignore[0] should be one of these:
       string | object { … }
@@ -77,7 +77,7 @@ exports[`validate options should throw an error on the "patterns" option with "[
 exports[`validate options should throw an error on the "patterns" option with "[{"from":"test.txt","to":"dir","context":"context","test":true}]" value 1`] = `
 "Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
  - options.patterns[0] should be one of these:
-   non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, cache?, transform?, transformPath?, … }
+   non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, transform?, cacheTransform?, transformPath?, … }
    Details:
     * options.patterns[0].test should be one of these:
       string | RegExp
@@ -105,13 +105,13 @@ exports[`validate options should throw an error on the "patterns" option with "[
 exports[`validate options should throw an error on the "patterns" option with "[{"from":"test.txt","to":"dir","context":"context"}]" value 1`] = `
 "Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
  - options.patterns[0] should be one of these:
-   non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, cache?, transform?, transformPath?, … }
+   non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, transform?, cacheTransform?, transformPath?, … }
    Details:
-    * options.patterns[0].cache should be one of these:
+    * options.patterns[0].cacheTransform should be one of these:
       boolean | object { … }
       Details:
-       * options.patterns[0].cache should be a boolean.
-       * options.patterns[0].cache should be an object:
+       * options.patterns[0].cacheTransform should be a boolean.
+       * options.patterns[0].cacheTransform should be an object:
          object { … }"
 `;
 
@@ -144,19 +144,19 @@ exports[`validate options should throw an error on the "patterns" option with "[
 exports[`validate options should throw an error on the "patterns" option with "{}" value 1`] = `
 "Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
  - options.patterns should be an array:
-   [non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, cache?, transform?, transformPath?, … }, ...] (should not have fewer than 1 item)"
+   [non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, transform?, cacheTransform?, transformPath?, … }, ...] (should not have fewer than 1 item)"
 `;
 
 exports[`validate options should throw an error on the "patterns" option with "true" value 1`] = `
 "Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
  - options.patterns should be an array:
-   [non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, cache?, transform?, transformPath?, … }, ...] (should not have fewer than 1 item)"
+   [non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, transform?, cacheTransform?, transformPath?, … }, ...] (should not have fewer than 1 item)"
 `;
 
 exports[`validate options should throw an error on the "patterns" option with "true" value 2`] = `
 "Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
  - options.patterns should be an array:
-   [non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, cache?, transform?, transformPath?, … }, ...] (should not have fewer than 1 item)"
+   [non-empty string | object { from, to?, context?, toType?, test?, force?, ignore?, flatten?, transform?, cacheTransform?, transformPath?, … }, ...] (should not have fewer than 1 item)"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "/test/" value 1`] = `

--- a/test/cacheTransform-option.test.js
+++ b/test/cacheTransform-option.test.js
@@ -27,7 +27,7 @@ describe('cache option', () => {
       patterns: [
         {
           from,
-          cache: true,
+          cacheTransform: true,
           transform: function transform(content) {
             return new Promise((resolve) => {
               resolve(`${content}changed!`);
@@ -74,7 +74,7 @@ describe('cache option', () => {
       patterns: [
         {
           from,
-          cache: true,
+          cacheTransform: true,
           transform: function transform(content) {
             return new Promise((resolve) => {
               resolve(`${content}changed!`);
@@ -114,7 +114,7 @@ describe('cache option', () => {
       patterns: [
         {
           from,
-          cache: true,
+          cacheTransform: true,
           transform: function transform(content) {
             return new Promise((resolve) => {
               resolve(`${content}changed!`);
@@ -156,7 +156,7 @@ describe('cache option', () => {
       patterns: [
         {
           from,
-          cache: {
+          cacheTransform: {
             key: 'foobar',
           },
           transform(content) {
@@ -198,7 +198,7 @@ describe('cache option', () => {
       patterns: [
         {
           from,
-          cache: true,
+          cacheTransform: true,
           // eslint-disable-next-line no-shadow
           transform: function transform(content) {
             expect(isGzip(content)).toBe(true);

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -64,8 +64,8 @@ describe('validate options', () => {
               },
             ],
             flatten: true,
-            cache: true,
             transform: () => {},
+            cacheTransform: true,
             transformPath: () => {},
           },
         ],
@@ -100,7 +100,7 @@ describe('validate options', () => {
             from: 'test.txt',
             to: 'dir',
             context: 'context',
-            cache: {
+            cacheTransform: {
               foo: 'bar',
             },
           },
@@ -203,7 +203,7 @@ describe('validate options', () => {
             from: 'test.txt',
             to: 'dir',
             context: 'context',
-            cache: () => {},
+            cacheTransform: () => {},
           },
         ],
         [


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Rename option to clarify

### Breaking Changes

Yes

BREAKING CHANGE: the `cache` option was renamed to `cacheTransform`

### Additional Info

No