### PR TITLE
refactor: remove the global `context` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,10 +547,9 @@ module.exports = {
 
 ### Options
 
-|         Name          |    Type    |          Default           | Description                                                                      |
-| :-------------------: | :--------: | :------------------------: | :------------------------------------------------------------------------------- |
-|  [`ignore`](#ignore)  | `{Array}`  |            `[]`            | Array of globs to ignore (applied to `from`)                                     |
-| [`context`](#context) | `{String}` | `compiler.options.context` | A path that determines how to interpret the `from` path, shared for all patterns |
+|        Name         |   Type    | Default | Description                                  |
+| :-----------------: | :-------: | :-----: | :------------------------------------------- |
+| [`ignore`](#ignore) | `{Array}` |  `[]`   | Array of globs to ignore (applied to `from`) |
 
 #### `ignore`
 
@@ -564,23 +563,6 @@ module.exports = {
     new CopyPlugin({
       patterns: [...patterns],
       options: { ignore: ['*.js', '*.css'] },
-    }),
-  ],
-};
-```
-
-#### `context`
-
-A path that determines how to interpret the `from` path, shared for all patterns.
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  plugins: [
-    new CopyPlugin({
-      patterns: [...patterns],
-      options: { context: '/app' },
     }),
   ],
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import validateOptions from 'schema-utils';
 
 import schema from './options.json';
@@ -21,40 +19,26 @@ class CopyPlugin {
   apply(compiler) {
     const fileDependencies = new Set();
     const contextDependencies = new Set();
-
-    let context;
-
-    if (!this.options.context) {
-      ({ context } = compiler.options);
-    } else if (!path.isAbsolute(this.options.context)) {
-      context = path.join(compiler.options.context, this.options.context);
-    } else {
-      ({ context } = this.options);
-    }
-
-    const logger = compiler.getInfrastructureLogger('copy-webpack-plugin');
-
     const plugin = { name: 'CopyPlugin' };
+    const logger = compiler.getInfrastructureLogger('copy-webpack-plugin');
 
     compiler.hooks.emit.tapAsync(plugin, (compilation, callback) => {
       logger.debug('starting emit');
 
       const globalRef = {
+        context: compiler.options.context,
         logger,
         compilation,
         fileDependencies,
         contextDependencies,
-        context,
         inputFileSystem: compiler.inputFileSystem,
         output: compiler.options.output.path,
         ignore: this.options.ignore || [],
         concurrency: this.options.concurrency,
       };
 
-      const { patterns } = this;
-
       Promise.all(
-        patterns.map((pattern) =>
+        this.patterns.map((pattern) =>
           Promise.resolve()
             .then(() => preProcessPattern(globalRef, pattern))
             // Every source (from) is assumed to exist here

--- a/src/options.json
+++ b/src/options.json
@@ -90,9 +90,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "context": {
-          "type": "string"
-        },
         "ignore": {
           "type": "array"
         }

--- a/src/preProcessPattern.js
+++ b/src/preProcessPattern.js
@@ -11,8 +11,8 @@ import { stat } from './utils/promisify';
 
 export default function preProcessPattern(globalRef, pattern) {
   const {
-    logger,
     context,
+    logger,
     inputFileSystem,
     fileDependencies,
     contextDependencies,

--- a/test/CopyPlugin.test.js
+++ b/test/CopyPlugin.test.js
@@ -387,9 +387,11 @@ describe('apply function', () => {
         patterns: [
           {
             from: 'tempfile1.txt',
+            context: 'watch',
           },
           {
             from: 'tempfile2.txt',
+            context: 'watch',
           },
         ],
       })
@@ -414,7 +416,7 @@ describe('apply function', () => {
         ),
         patterns: [
           {
-            from: 'directory',
+            from: 'watch/directory',
           },
         ],
       })
@@ -439,7 +441,7 @@ describe('apply function', () => {
         ),
         patterns: [
           {
-            context: 'directory',
+            context: 'watch/directory',
             from: '**/*.txt',
             to: 'dest1',
           },
@@ -471,12 +473,12 @@ describe('apply function', () => {
         ),
         patterns: [
           {
-            context: 'directory',
+            context: 'watch/directory',
             from: '**/*.txt',
             to: 'dest1',
           },
           {
-            context: 'directory',
+            context: 'watch/directory',
             from: '**/*.txt',
             to: 'dest2',
           },
@@ -502,11 +504,12 @@ describe('apply function', () => {
         newFileLoc2: path.join(FIXTURES_DIR, 'watch', 'tempfile2.txt'),
         patterns: [
           {
-            context: 'directory',
+            context: 'watch/directory',
             from: '**/*.txt',
             to: 'dest1',
           },
           {
+            context: 'watch',
             from: '**/*.txt',
             to: 'dest2',
           },

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -1,14 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validate options should throw an error on the "options" option with "{"context":true}" value 1`] = `
-"Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
- - options.options.context should be a string."
-`;
-
 exports[`validate options should throw an error on the "options" option with "{"ignore":true}" value 1`] = `
 "Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
  - options.options.ignore should be an array:
    [any, ...]"
+`;
+
+exports[`validate options should throw an error on the "options" option with "{"unknown":true}" value 1`] = `
+"Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
+ - options.options has an unknown property 'unknown'. These properties are valid:
+   object { ignore? }"
 `;
 
 exports[`validate options should throw an error on the "patterns" option with "" value 1`] = `

--- a/test/context-option.test.js
+++ b/test/context-option.test.js
@@ -5,13 +5,89 @@ import { runEmit } from './helpers/run';
 const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
 describe('context option', () => {
-  it('should work when "from" is a file', (done) => {
+  it('should work when "from" is a file and "context" is a relative path', (done) => {
     runEmit({
       expectedAssetKeys: ['directoryfile.txt'],
       patterns: [
         {
           from: 'directoryfile.txt',
           context: 'directory',
+        },
+      ],
+    })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should work when "from" is a directory and "context" is a relative path', (done) => {
+    runEmit({
+      expectedAssetKeys: ['deep-nested/deepnested.txt', 'nestedfile.txt'],
+      patterns: [
+        {
+          from: 'nested',
+          context: 'directory',
+        },
+      ],
+    })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should work when "from" is a glob and "context" is a relative path', (done) => {
+    runEmit({
+      expectedAssetKeys: [
+        'nested/deep-nested/deepnested.txt',
+        'nested/nestedfile.txt',
+      ],
+      patterns: [
+        {
+          from: 'nested/**/*',
+          context: 'directory',
+        },
+      ],
+    })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should work when "from" is a file and "context" is an absolute path', (done) => {
+    runEmit({
+      expectedAssetKeys: ['directoryfile.txt'],
+      patterns: [
+        {
+          from: 'directoryfile.txt',
+          context: path.join(FIXTURES_DIR, 'directory'),
+        },
+      ],
+    })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should work when "from" is a directory and "context" is an absolute path', (done) => {
+    runEmit({
+      expectedAssetKeys: ['deep-nested/deepnested.txt', 'nestedfile.txt'],
+      patterns: [
+        {
+          from: 'nested',
+          context: path.join(FIXTURES_DIR, 'directory'),
+        },
+      ],
+    })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should work when "from" is a glob and "context" is an absolute path', (done) => {
+    runEmit({
+      expectedAssetKeys: [
+        'nested/deep-nested/deepnested.txt',
+        'nested/nestedfile.txt',
+      ],
+      patterns: [
+        {
+          from: 'nested/**/*',
+          context: path.join(FIXTURES_DIR, 'directory'),
         },
       ],
     })
@@ -33,38 +109,6 @@ describe('context option', () => {
       .catch(done);
   });
 
-  it('should work when "from" is a directory', (done) => {
-    runEmit({
-      expectedAssetKeys: ['deep-nested/deepnested.txt', 'nestedfile.txt'],
-      patterns: [
-        {
-          from: 'nested',
-          context: 'directory',
-        },
-      ],
-    })
-      .then(done)
-      .catch(done);
-  });
-
-  it('should work when "from" is a directory and "to" is a new directory', (done) => {
-    runEmit({
-      expectedAssetKeys: [
-        'newdirectory/deep-nested/deepnested.txt',
-        'newdirectory/nestedfile.txt',
-      ],
-      patterns: [
-        {
-          context: 'directory',
-          from: 'nested',
-          to: 'newdirectory',
-        },
-      ],
-    })
-      .then(done)
-      .catch(done);
-  });
-
   it('should work when "from" is a directory and "context" with special characters', (done) => {
     runEmit({
       expectedAssetKeys: [
@@ -77,61 +121,6 @@ describe('context option', () => {
           // Todo strange behavour when you use `FIXTURES_DIR`, need investigate for next major release
           from: '.',
           context: '[special?directory]',
-        },
-      ],
-    })
-      .then(done)
-      .catch(done);
-  });
-
-  it('should work when "from" is a glob', (done) => {
-    runEmit({
-      expectedAssetKeys: [
-        'nested/deep-nested/deepnested.txt',
-        'nested/nestedfile.txt',
-      ],
-      patterns: [
-        {
-          from: 'nested/**/*',
-          context: 'directory',
-        },
-      ],
-    })
-      .then(done)
-      .catch(done);
-  });
-
-  it('should work when "from" is a glob and "to" is a directory', (done) => {
-    runEmit({
-      expectedAssetKeys: [
-        'nested/directoryfile.txt',
-        'nested/nested/deep-nested/deepnested.txt',
-        'nested/nested/nestedfile.txt',
-      ],
-      patterns: [
-        {
-          context: 'directory',
-          from: '**/*',
-          to: 'nested',
-        },
-      ],
-    })
-      .then(done)
-      .catch(done);
-  });
-
-  it('should work when "from" is a glob and "to" is a directory and "content" is an absolute path', (done) => {
-    runEmit({
-      expectedAssetKeys: [
-        'nested/directoryfile.txt',
-        'nested/nested/deep-nested/deepnested.txt',
-        'nested/nested/nestedfile.txt',
-      ],
-      patterns: [
-        {
-          context: path.join(FIXTURES_DIR, 'directory'),
-          from: '**/*',
-          to: 'nested',
         },
       ],
     })
@@ -171,13 +160,14 @@ describe('context option', () => {
       .catch(done);
   });
 
-  it('should work when "from" is a file and "context" is an absolute path', (done) => {
+  it('should work when "from" is a file and "to" is a directory', (done) => {
     runEmit({
-      expectedAssetKeys: ['directoryfile.txt'],
+      expectedAssetKeys: ['newdirectory/directoryfile.txt'],
       patterns: [
         {
+          context: 'directory',
           from: 'directoryfile.txt',
-          context: path.join(FIXTURES_DIR, 'directory'),
+          to: 'newdirectory',
         },
       ],
     })
@@ -185,17 +175,15 @@ describe('context option', () => {
       .catch(done);
   });
 
-  it('should override webpack config context with an absolute path', (done) => {
+  it('should work when "from" is a directory and "to" is a directory', (done) => {
     runEmit({
       expectedAssetKeys: [
         'newdirectory/deep-nested/deepnested.txt',
         'newdirectory/nestedfile.txt',
       ],
-      options: {
-        context: path.join(FIXTURES_DIR, 'directory'),
-      },
       patterns: [
         {
+          context: 'directory',
           from: 'nested',
           to: 'newdirectory',
         },
@@ -205,61 +193,18 @@ describe('context option', () => {
       .catch(done);
   });
 
-  it('should override webpack config context with a relative path', (done) => {
+  it('should work when "from" is a glob and "to" is a directory', (done) => {
     runEmit({
       expectedAssetKeys: [
-        'newdirectory/deep-nested/deepnested.txt',
-        'newdirectory/nestedfile.txt',
+        'nested/directoryfile.txt',
+        'nested/nested/deep-nested/deepnested.txt',
+        'nested/nested/nestedfile.txt',
       ],
-      options: {
-        context: 'directory',
-      },
       patterns: [
         {
-          from: 'nested',
-          to: 'newdirectory',
-        },
-      ],
-    })
-      .then(done)
-      .catch(done);
-  });
-
-  it('should override global context on pattern context with a relative path', (done) => {
-    runEmit({
-      expectedAssetKeys: [
-        'newdirectory/deep-nested/deepnested.txt',
-        'newdirectory/nestedfile.txt',
-      ],
-      options: {
-        context: 'directory',
-      },
-      patterns: [
-        {
-          context: 'nested',
-          from: '.',
-          to: 'newdirectory',
-        },
-      ],
-    })
-      .then(done)
-      .catch(done);
-  });
-
-  it('overrides webpack config context with an absolute path', (done) => {
-    runEmit({
-      expectedAssetKeys: [
-        'newdirectory/file.txt',
-        'newdirectory/nesteddir/deepnesteddir/deepnesteddir.txt',
-        'newdirectory/nesteddir/nestedfile.txt',
-      ],
-      options: {
-        context: path.join(FIXTURES_DIR, 'dir (86)'),
-      },
-      patterns: [
-        {
+          context: 'directory',
           from: '**/*',
-          to: 'newdirectory',
+          to: 'nested',
         },
       ],
     })

--- a/test/helpers/run.js
+++ b/test/helpers/run.js
@@ -173,7 +173,7 @@ function runChange(opts) {
 
   return run({
     compiler,
-    options: Object.assign({}, opts.options, { context: 'watch' }),
+    options: Object.assign({}, opts.options),
     patterns: opts.patterns,
   })
     .then(() => {

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -235,8 +235,8 @@ describe('validate options', () => {
       ],
     },
     options: {
-      success: [{ context: 'context' }, { ignore: ['test'] }],
-      failure: [{ context: true }, { ignore: true }],
+      success: [{ ignore: ['test'] }],
+      failure: [{ unknown: true }, { ignore: true }],
     },
     unknown: {
       success: [],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

No need extra option (less options), you already have `context` option on pattern level

### Breaking Changes

BREAKING CHANGE: the global `context` option was removed in favor the `patten.context` option

### Additional Info

No