### PR TITLE
docs: add ignore syntax change to breaking changes in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ All notable changes to this project will be documented in this file. See [standa
 * minimum supported Node.js version is `10.13`, 
 * the plugin now accepts an object, you should change `new CopyPlugin(patterns, options)` to `new CopyPlugin({ patterns, options })`
 * migrate on `compilation.additionalAssets` hook
-* the `ignore` option was removed in favor `globOptions.ignore`
+* the `ignore` option (which accepted [micromatch](https://github.com/micromatch/micromatch) syntax) was removed in favor `globOptions.ignore` (which accepts [fast-glob pattern-syntax](https://github.com/mrmlnc/fast-glob#pattern-syntax))
 * the `test` option was removed in favor the `transformPath` option
 * the `cache` option was renamed to the `cacheTransform` option, `cacheTransform` option should have only `directory` and `keys` properties when it is an object
 * global `context` and `ignore` options were removed in favor `patten.context` and `pattern.globOptions.ignore` options


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

The syntax change of the ignore option made in #463 wasn’t reflected in the CHANGELOG. Now it has been made clear that there was a change in syntax, and a link to both the old and the new syntax have been added.