### PR TITLE
docs: remove "$" from copied console line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Copies individual files or entire directories, which already exist, to the build
 To begin, you'll need to install `copy-webpack-plugin`:
 
 ```console
-$ npm install copy-webpack-plugin --save-dev
+npm install copy-webpack-plugin --save-dev
 ```
 
 Then add the plugin to your `webpack` config. For example:


### PR DESCRIPTION
For easy copying of the plugin installation command

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**
