### PR TITLE
refactor: template strings in `to` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ module.exports = {
         },
         {
           from: "**/*",
-          to: "[path][name].[contenthash].[ext]",
+          to: "[path][name].[contenthash][ext]",
         },
       ],
     }),
@@ -371,11 +371,11 @@ Sometimes it is hard to say what is `to`, example `path/to/dir-with.ext`.
 If you want to copy files in directory you need use `dir` option.
 We try to automatically determine the `type` so you most likely do not need this option.
 
-|       Name       |    Type    |   Default   | Description                                                                                        |
-| :--------------: | :--------: | :---------: | :------------------------------------------------------------------------------------------------- |
-|   **`'dir'`**    | `{String}` | `undefined` | If `to` has no extension or ends on `'/'`                                                          |
-|   **`'file'`**   | `{String}` | `undefined` | If `to` is not a directory and is not a template                                                   |
-| **`'template'`** | `{String}` | `undefined` | If `to` contains [a template pattern](https://github.com/webpack-contrib/file-loader#placeholders) |
+|       Name       |    Type    |   Default   | Description                                                                                          |
+| :--------------: | :--------: | :---------: | :--------------------------------------------------------------------------------------------------- |
+|   **`'dir'`**    | `{String}` | `undefined` | If `to` has no extension or ends on `'/'`                                                            |
+|   **`'file'`**   | `{String}` | `undefined` | If `to` is not a directory and is not a template                                                     |
+| **`'template'`** | `{String}` | `undefined` | If `to` contains [a template pattern](https://webpack.js.org/configuration/output/#template-strings) |
 
 ##### `'dir'`
 
@@ -428,7 +428,7 @@ module.exports = {
       patterns: [
         {
           from: "src/",
-          to: "dest/[name].[hash].[ext]",
+          to: "dest/[name].[contenthash][ext]",
           toType: "template",
         },
       ],
@@ -995,7 +995,7 @@ module.exports = {
       patterns: [
         {
           from: "src/**/*",
-          to: "[name].[ext]",
+          to: "[name][ext]",
         },
       ],
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,9 +93,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
-      "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.13.0",
@@ -166,9 +166,9 @@
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.4.tgz",
-      "integrity": "sha512-K5V2GaQZ1gpB+FTXM4AFVG2p1zzhm67n9wrQCJYNzvuLzQybhJyftW7qeDd2uUxPDNdl5Rkon1rOAeUeNDZ28Q==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz",
+      "integrity": "sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==",
       "dev": true,
       "requires": {
         "@babel/helper-compilation-targets": "^7.13.0",
@@ -390,9 +390,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
-      "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
+      "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -969,9 +969,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.8.tgz",
-      "integrity": "sha512-Sso1xOpV4S3ofnxW2DsWTE5ziRk62jEAKLGuQ+EJHC+YHTbFG38QUTixO3JVa1cYET9gkJhO1pMu+/+2dDhKvw==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.9.tgz",
+      "integrity": "sha512-mcsHUlh2rIhViqMG823JpscLMesRt3QbMsv1+jhopXEb3W2wXvQ9QoiOlZI9ZbR3XqPtaFpZwEZKYqGJnGMZTQ==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.13.8",
@@ -1066,9 +1066,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.8.tgz",
-      "integrity": "sha512-CwQljpw6qSayc0fRG1soxHAKs1CnQMOChm4mlQP6My0kf9upVGizj/KhlTTgyUnETmHpcUXjaluNAkteRFuafg==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
+      "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -1508,9 +1508,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -1520,7 +1520,6 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -2366,9 +2365,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-DxZZbyMAM9GWEzXL+BMZROWz9oo6A9EilwwOMET2UVu2uZTqMWS5S69KVtuVKaRjCUpcrOXRalet86/OpG4kqw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.2.tgz",
+      "integrity": "sha512-i99hy7Ki19EqVOl77WplDrvgNugHnsSjECVR/wUrzw2TJXz1zlUfT2ngGckR6xN7yFYaijsMAqPkOLx9HgUqHg==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -2553,26 +2552,6 @@
         "user-meta": "^1.0.0"
       },
       "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^1.0.1"
-          }
-        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -3153,13 +3132,13 @@
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.8.tgz",
-      "integrity": "sha512-kB5/xNR9GYDuRmVlL9EGfdKBSUVI/9xAU7PCahA/1hbC2Jbmks9dlBBYjHF9IHMNY2jV/G2lIG7z0tJIW27Rog==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz",
+      "integrity": "sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.13.0",
-        "@babel/helper-define-polyfill-provider": "^0.1.4",
+        "@babel/helper-define-polyfill-provider": "^0.1.5",
         "semver": "^6.1.1"
       },
       "dependencies": {
@@ -3172,22 +3151,22 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.6.tgz",
-      "integrity": "sha512-IkYhCxPrjrUWigEmkMDXYzM5iblzKCdCD8cZrSAkQOyhhJm26DcG+Mxbx13QT//Olkpkg/AlRdT2L+Ww4Ciphw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz",
+      "integrity": "sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.1.4",
+        "@babel/helper-define-polyfill-provider": "^0.1.5",
         "core-js-compat": "^3.8.1"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.5.tgz",
-      "integrity": "sha512-EyhBA6uN94W97lR7ecQVTvH9F5tIIdEw3ZqHuU4zekMlW82k5cXNXniiB7PRxQm06BqAjVr4sDT1mOy4RcphIA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz",
+      "integrity": "sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.1.4"
+        "@babel/helper-define-polyfill-provider": "^0.1.5"
       }
     },
     "babel-preset-current-node-syntax": {
@@ -3293,7 +3272,8 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -3405,9 +3385,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001192",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001192.tgz",
-      "integrity": "sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw==",
+      "version": "1.0.30001194",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz",
+      "integrity": "sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA==",
       "dev": true
     },
     "capture-exit": {
@@ -4095,9 +4075,9 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.0.tgz",
-      "integrity": "sha512-YK6fwFjCOKWwGnjFUR3c544YsnA/7DoLL0ysncuOJ4pwbriAtOpvM2bygdlcXbvQCQZ7bBU9CL4t7tGl7ETRpQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.1.tgz",
+      "integrity": "sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.3",
@@ -4670,9 +4650,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.675",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.675.tgz",
-      "integrity": "sha512-GEQw+6dNWjueXGkGfjgm7dAMtXfEqrfDG3uWcZdeaD4cZ3dKYdPRQVruVXQRXtPLtOr5GNVVlNLRMChOZ611pQ==",
+      "version": "1.3.677",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.677.tgz",
+      "integrity": "sha512-Tcmk+oKQgpjcM+KYanlkd76ZtpzalkpUULnlJDP6vjHtR7UU564IM9Qv5DxqHZNBQjzXm6mkn7Y8bw2OoE3FmQ==",
       "dev": true
     },
     "emittery": {
@@ -4690,7 +4670,8 @@
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -4730,25 +4711,27 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0-next.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+      "version": "1.18.0-next.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
+      "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
         "object-inspect": "^1.9.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.3",
-        "string.prototype.trimstart": "^1.0.3"
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       }
     },
     "es-module-lexer": {
@@ -4848,13 +4831,13 @@
       }
     },
     "eslint": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
+      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.3.0",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -4867,7 +4850,7 @@
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
@@ -5311,9 +5294,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true
     },
     "exec-sh": {
@@ -5590,15 +5573,15 @@
         "schema-utils": "^3.0.0"
       },
       "dependencies": {
-        "schema-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
           "dev": true,
           "requires": {
-            "@types/json-schema": "^7.0.6",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
           }
         }
       }
@@ -6243,6 +6226,12 @@
         }
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -6250,9 +6239,9 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
     "has-value": {
@@ -6358,9 +6347,9 @@
       "dev": true
     },
     "husky": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-5.1.1.tgz",
-      "integrity": "sha512-80LZ736V0Nr4/st0c2COYaMbEQhHNmAbLMN8J/kLk7/mo0QdUkUGNDjv/7jVkhug377Wh8wfbWyaVXEJ/h2B/Q==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-5.1.3.tgz",
+      "integrity": "sha512-fbNJ+Gz5wx2LIBtMweJNY1D7Uc8p1XERi5KNRMccwfQA+rXlxWNSdUxswo0gT8XqxywTIw7Ywm/F4v/O35RdMg==",
       "dev": true
     },
     "iconv-lite": {
@@ -6488,6 +6477,12 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -6496,6 +6491,15 @@
       "optional": true,
       "requires": {
         "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -6633,6 +6637,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true
     },
     "is-obj": {
       "version": "2.0.0",
@@ -8389,6 +8399,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -8742,13 +8753,25 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-      "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
+        "json5": "^1.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
       }
     },
     "locate-path": {
@@ -9045,7 +9068,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -11255,9 +11279,9 @@
       }
     },
     "string-width": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
-      "integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
@@ -11509,17 +11533,6 @@
         "terser": "^5.5.1"
       },
       "dependencies": {
-        "schema-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.6",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11750,11 +11763,23 @@
       }
     },
     "uglify-js": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
-      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.0.tgz",
+      "integrity": "sha512-TWYSWa9T2pPN4DIJYbU9oAjQx+5qdV5RUDxwARg8fmJZrD/V27Zj0JngW5xg1DFz42G0uDYl2XhzF6alSzD62w==",
       "dev": true,
       "optional": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
+      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.0",
+        "has-symbols": "^1.0.0",
+        "which-boxed-primitive": "^1.0.1"
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -12016,17 +12041,6 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
           "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
           "dev": true
-        },
-        "schema-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.6",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
         }
       }
     },
@@ -12090,6 +12104,19 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
       }
     },
     "which-module": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "fast-glob": "^3.2.5",
     "glob-parent": "^5.1.1",
     "globby": "^11.0.2",
-    "loader-utils": "^2.0.0",
     "normalize-path": "^3.0.0",
     "p-limit": "^3.0.2",
     "schema-utils": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -547,10 +547,7 @@ class CopyPlugin {
             const ext = path.extname(result.sourceFilename);
             const base = path.basename(result.sourceFilename);
             const name = base.slice(0, base.length - ext.length);
-            const {
-              path: interpolatedFilename,
-              info: assetInfo,
-            } = compilation.getPathWithInfo(result.filename, {
+            const data = {
               filename: normalizePath(
                 path.relative(pattern.context, absoluteFilename)
               ),
@@ -561,7 +558,14 @@ class CopyPlugin {
                 hash: contentHash,
                 contentHash,
               },
-            });
+            };
+            const {
+              path: interpolatedFilename,
+              info: assetInfo,
+            } = compilation.getPathWithInfo(
+              normalizePath(result.filename),
+              data
+            );
 
             result.info = { ...result.info, ...assetInfo };
             result.filename = interpolatedFilename;

--- a/test/CopyPlugin.test.js
+++ b/test/CopyPlugin.test.js
@@ -310,17 +310,17 @@ describe("CopyPlugin", () => {
       expect.assertions(5);
 
       const expectedAssetKeys = [
-        "directoryfile.5d7817ed5bc246756d73d6a4c8e94c33.txt",
-        ".dottedfile.5e294e270db6734a42f014f0dd18d9ac",
-        "nested/nestedfile.31d6cfe0d16ae931b73c59d7e0c089c0.txt",
-        "nested/deep-nested/deepnested.31d6cfe0d16ae931b73c59d7e0c089c0.txt",
+        "directoryfile.5d7817ed5bc246756d73.txt",
+        ".dottedfile.5e294e270db6734a42f0",
+        "nested/nestedfile.31d6cfe0d16ae931b73c.txt",
+        "nested/deep-nested/deepnested.31d6cfe0d16ae931b73c.txt",
       ];
 
       run({
         preCopy: {
           additionalAssets: [
             {
-              name: "directoryfile.5d7817ed5bc246756d73d6a4c8e94c33.txt",
+              name: "directoryfile.5d7817ed5bc246756d73.txt",
               data: "Content",
               info: { custom: true },
             },
@@ -330,7 +330,7 @@ describe("CopyPlugin", () => {
         patterns: [
           {
             from: "directory",
-            to: "[path][name].[contenthash].[ext]",
+            to: "[path][name].[contenthash][ext]",
             force: true,
           },
         ],
@@ -341,7 +341,7 @@ describe("CopyPlugin", () => {
 
             expect(info.immutable).toBe(true);
 
-            if (name === "directoryfile.5d7817ed5bc246756d73d6a4c8e94c33.txt") {
+            if (name === "directoryfile.5d7817ed5bc246756d73.txt") {
               expect(info.immutable).toBe(true);
             }
           }

--- a/test/from-option.test.js
+++ b/test/from-option.test.js
@@ -1,6 +1,7 @@
 import path from "path";
 
 import { runEmit } from "./helpers/run";
+import { getCompiler } from "./helpers";
 
 const FIXTURES_DIR_NORMALIZED = path
   .join(__dirname, "fixtures")
@@ -389,7 +390,14 @@ describe("from option", () => {
     });
 
     it("should move files in nested directory using globstar", (done) => {
+      const compiler = getCompiler({
+        output: {
+          hashDigestLength: 6,
+        },
+      });
+
       runEmit({
+        compiler,
         expectedAssetKeys: [
           "nested/[(){}[]!+@escaped-test^$]/hello-31d6cf.txt",
           "nested/binextension-31d6cf.bin",
@@ -409,7 +417,7 @@ describe("from option", () => {
         patterns: [
           {
             from: "**/*",
-            to: "nested/[path][name]-[hash:6].[ext]",
+            to: "nested/[path][name]-[contenthash][ext]",
           },
         ],
       })

--- a/test/from-option.test.js
+++ b/test/from-option.test.js
@@ -9,7 +9,7 @@ const FIXTURES_DIR_NORMALIZED = path
 
 describe("from option", () => {
   describe("is a file", () => {
-    it("should move a file", (done) => {
+    it("should copy a file", (done) => {
       runEmit({
         expectedAssetKeys: ["file.txt"],
         patterns: [
@@ -22,7 +22,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it('should move a file when "from" an absolute path', (done) => {
+    it('should copy a file when "from" an absolute path', (done) => {
       runEmit({
         expectedAssetKeys: ["file.txt"],
         patterns: [
@@ -35,7 +35,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move a file from nesting directory", (done) => {
+    it("should copy a file from nesting directory", (done) => {
       runEmit({
         expectedAssetKeys: ["directoryfile.txt"],
         patterns: [
@@ -48,7 +48,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it('should move a file from nesting directory when "from" an absolute path', (done) => {
+    it('should copy a file from nesting directory when "from" an absolute path', (done) => {
       runEmit({
         expectedAssetKeys: ["directoryfile.txt"],
         patterns: [
@@ -64,7 +64,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move a file (symbolic link)", (done) => {
+    it("should copy a file (symbolic link)", (done) => {
       runEmit({
         symlink: true,
         expectedErrors:
@@ -106,7 +106,7 @@ describe("from option", () => {
   });
 
   describe("is a directory", () => {
-    it("should move files", (done) => {
+    it("should copy files", (done) => {
       runEmit({
         expectedAssetKeys: [
           ".dottedfile",
@@ -124,7 +124,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it('should move files when "from" is current directory', (done) => {
+    it('should copy files when "from" is current directory', (done) => {
       runEmit({
         expectedAssetKeys: [
           ".file.txt",
@@ -154,7 +154,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it('should move files when "from" is relative path to context', (done) => {
+    it('should copy files when "from" is relative path to context', (done) => {
       runEmit({
         expectedAssetKeys: [
           ".file.txt",
@@ -184,7 +184,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files with a forward slash", (done) => {
+    it("should copy files with a forward slash", (done) => {
       runEmit({
         expectedAssetKeys: [
           ".dottedfile",
@@ -202,7 +202,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files from symbolic link", (done) => {
+    it("should copy files from symbolic link", (done) => {
       runEmit({
         // Windows doesn't support symbolic link
         symlink: true,
@@ -228,7 +228,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files when 'from' is a absolute path", (done) => {
+    it("should copy files when 'from' is a absolute path", (done) => {
       runEmit({
         expectedAssetKeys: [
           ".dottedfile",
@@ -246,7 +246,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files when 'from' with special characters", (done) => {
+    it("should copy files when 'from' with special characters", (done) => {
       runEmit({
         expectedAssetKeys: [
           "directoryfile.txt",
@@ -264,7 +264,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files from nested directory", (done) => {
+    it("should copy files from nested directory", (done) => {
       runEmit({
         expectedAssetKeys: ["deep-nested/deepnested.txt", "nestedfile.txt"],
         patterns: [
@@ -277,7 +277,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files from nested directory with an absolute path", (done) => {
+    it("should copy files from nested directory with an absolute path", (done) => {
       runEmit({
         expectedAssetKeys: ["deep-nested/deepnested.txt", "nestedfile.txt"],
         patterns: [
@@ -310,7 +310,7 @@ describe("from option", () => {
   });
 
   describe("is a glob", () => {
-    it("should move files", (done) => {
+    it("should copy files", (done) => {
       runEmit({
         expectedAssetKeys: ["file.txt"],
         patterns: [
@@ -323,7 +323,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files when a glob contains absolute path", (done) => {
+    it("should copy files when a glob contains absolute path", (done) => {
       runEmit({
         expectedAssetKeys: ["file.txt"],
         patterns: [
@@ -336,7 +336,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files using globstar", (done) => {
+    it("should copy files using globstar", (done) => {
       runEmit({
         expectedAssetKeys: [
           "[(){}[]!+@escaped-test^$]/hello.txt",
@@ -364,7 +364,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files using globstar and contains an absolute path", (done) => {
+    it("should copy files using globstar and contains an absolute path", (done) => {
       runEmit({
         expectedAssetKeys: [
           "[(){}[]!+@escaped-test^$]/hello.txt",
@@ -389,7 +389,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files in nested directory using globstar", (done) => {
+    it("should copy files in nested directory using globstar", (done) => {
       const compiler = getCompiler({
         output: {
           hashDigestLength: 6,
@@ -425,7 +425,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files from nested directory", (done) => {
+    it("should copy files from nested directory", (done) => {
       runEmit({
         expectedAssetKeys: ["directory/directoryfile.txt"],
         patterns: [
@@ -438,7 +438,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files from nested directory #2", (done) => {
+    it("should copy files from nested directory #2", (done) => {
       runEmit({
         expectedAssetKeys: [
           "directory/directoryfile.txt",
@@ -455,7 +455,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files using bracketed glob", (done) => {
+    it("should copy files using bracketed glob", (done) => {
       runEmit({
         expectedAssetKeys: [
           "directory/directoryfile.txt",
@@ -474,7 +474,7 @@ describe("from option", () => {
         .catch(done);
     });
 
-    it("should move files (symbolic link)", (done) => {
+    it("should copy files (symbolic link)", (done) => {
       runEmit({
         // Windows doesn't support symbolic link
         symlink: true,

--- a/test/globOptions-option.test.js
+++ b/test/globOptions-option.test.js
@@ -8,7 +8,7 @@ const FIXTURES_DIR_NORMALIZED = path
 
 describe("globOptions option", () => {
   // Expected behavior from `globby`/`fast-glob`
-  it('should move files exclude dot files when "from" is a directory', (done) => {
+  it('should copy files exclude dot files when "from" is a directory', (done) => {
     runEmit({
       expectedAssetKeys: [".file.txt"],
       patterns: [
@@ -24,7 +24,7 @@ describe("globOptions option", () => {
       .catch(done);
   });
 
-  it('should move files exclude dot files when "from" is a directory', (done) => {
+  it('should copy files exclude dot files when "from" is a directory', (done) => {
     runEmit({
       expectedAssetKeys: [
         "directoryfile.txt",
@@ -44,7 +44,7 @@ describe("globOptions option", () => {
       .catch(done);
   });
 
-  it('should move files exclude dot files when "from" is a glob', (done) => {
+  it('should copy files exclude dot files when "from" is a glob', (done) => {
     runEmit({
       expectedAssetKeys: ["file.txt"],
       patterns: [
@@ -60,7 +60,7 @@ describe("globOptions option", () => {
       .catch(done);
   });
 
-  it("should move files include dot files", (done) => {
+  it("should copy files include dot files", (done) => {
     runEmit({
       expectedAssetKeys: [".file.txt", "file.txt"],
       patterns: [

--- a/test/helpers/BreakContenthashPlugin.js
+++ b/test/helpers/BreakContenthashPlugin.js
@@ -1,0 +1,33 @@
+class BreakContenthashPlugin {
+  constructor(options = {}) {
+    this.options = options.options || {};
+  }
+
+  apply(compiler) {
+    const plugin = { name: "BrokeContenthashPlugin" };
+
+    compiler.hooks.thisCompilation.tap(plugin, (compilation) => {
+      compilation.hooks.processAssets.tapAsync(
+        {
+          name: "broken-contenthash-webpack-plugin",
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
+        },
+        (unusedAssets, callback) => {
+          this.options.targetAssets.forEach(({ name, newName, newHash }) => {
+            const asset = compilation.getAsset(name);
+
+            compilation.updateAsset(asset.name, asset.source, {
+              ...asset.info,
+              contenthash: newHash,
+            });
+            compilation.renameAsset(asset.name, newName);
+          });
+
+          callback();
+        }
+      );
+    });
+  }
+}
+
+export default BreakContenthashPlugin;

--- a/test/helpers/run.js
+++ b/test/helpers/run.js
@@ -6,6 +6,7 @@ import CopyPlugin from "../../src/index";
 
 import ChildCompilerPlugin from "./ChildCompiler";
 import PreCopyPlugin from "./PreCopyPlugin";
+import BreakContenthashPlugin from "./BreakContenthashPlugin";
 
 import removeIllegalCharacterForWindows from "./removeIllegalCharacterForWindows";
 
@@ -47,6 +48,12 @@ function run(opts) {
 
     if (opts.preCopy) {
       new PreCopyPlugin({ options: opts.preCopy }).apply(compiler);
+    }
+
+    if (opts.breakContenthash) {
+      new BreakContenthashPlugin({ options: opts.breakContenthash }).apply(
+        compiler
+      );
     }
 
     new CopyPlugin({ patterns: opts.patterns, options: opts.options }).apply(

--- a/test/to-option.test.js
+++ b/test/to-option.test.js
@@ -9,7 +9,7 @@ const FIXTURES_DIR = path.join(__dirname, "fixtures");
 
 describe("to option", () => {
   describe("is a file", () => {
-    it("should move a file to a new file", (done) => {
+    it("should copy a file to a new file", (done) => {
       runEmit({
         expectedAssetKeys: ["newfile.txt"],
         patterns: [
@@ -23,7 +23,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file to a new file when "to" is absolute path', (done) => {
+    it('should copy a file to a new file when "to" is absolute path', (done) => {
       runEmit({
         expectedAssetKeys: ["../tempdir/newfile.txt"],
         patterns: [
@@ -37,7 +37,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file to a new file inside nested directory", (done) => {
+    it("should copy a file to a new file inside nested directory", (done) => {
       runEmit({
         expectedAssetKeys: ["newdirectory/newfile.txt"],
         patterns: [
@@ -51,7 +51,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file to a new file inside nested directory when "to" an absolute path', (done) => {
+    it('should copy a file to a new file inside nested directory when "to" an absolute path', (done) => {
       runEmit({
         expectedAssetKeys: ["newdirectory/newfile.txt"],
         patterns: [
@@ -65,7 +65,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file to a new file inside other directory what out of context", (done) => {
+    it("should copy a file to a new file inside other directory what out of context", (done) => {
       runEmit({
         expectedAssetKeys: ["../tempdir/newdirectory/newfile.txt"],
         patterns: [
@@ -79,7 +79,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file using invalid template syntax", (done) => {
+    it("should copy a file using invalid template syntax", (done) => {
       runEmit({
         expectedAssetKeys: ["directory/[md5::base64:20].txt"],
         patterns: [
@@ -95,7 +95,7 @@ describe("to option", () => {
   });
 
   describe("is a directory", () => {
-    it("should move a file to a new directory", (done) => {
+    it("should copy a file to a new directory", (done) => {
       runEmit({
         expectedAssetKeys: ["newdirectory/file.txt"],
         patterns: [
@@ -109,7 +109,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file to a new directory out of context", (done) => {
+    it("should copy a file to a new directory out of context", (done) => {
       runEmit({
         expectedAssetKeys: ["../tempdir/file.txt"],
         patterns: [
@@ -123,7 +123,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file to a new directory with a forward slash", (done) => {
+    it("should copy a file to a new directory with a forward slash", (done) => {
       runEmit({
         expectedAssetKeys: ["newdirectory/file.txt"],
         patterns: [
@@ -137,7 +137,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file to a new directory with an extension and path separator at end", (done) => {
+    it("should copy a file to a new directory with an extension and path separator at end", (done) => {
       runEmit({
         expectedAssetKeys: ["newdirectory.ext/file.txt"],
         patterns: [
@@ -151,7 +151,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file to a new directory when "to" is absolute path', (done) => {
+    it('should copy a file to a new directory when "to" is absolute path', (done) => {
       runEmit({
         expectedAssetKeys: ["file.txt"],
         patterns: [
@@ -165,7 +165,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file to a new directory when "to" is absolute path with a forward slash', (done) => {
+    it('should copy a file to a new directory when "to" is absolute path with a forward slash', (done) => {
       runEmit({
         expectedAssetKeys: ["file.txt"],
         patterns: [
@@ -179,7 +179,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file to a new directory from nested directory", (done) => {
+    it("should copy a file to a new directory from nested directory", (done) => {
       runEmit({
         expectedAssetKeys: ["newdirectory/directoryfile.txt"],
         patterns: [
@@ -193,7 +193,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file to a new directory from nested directory when "from" is absolute path', (done) => {
+    it('should copy a file to a new directory from nested directory when "from" is absolute path', (done) => {
       runEmit({
         expectedAssetKeys: ["newdirectory/directoryfile.txt"],
         patterns: [
@@ -207,7 +207,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file to a new directory from nested directory when "from" is absolute path with a forward slash', (done) => {
+    it('should copy a file to a new directory from nested directory when "from" is absolute path with a forward slash', (done) => {
       runEmit({
         expectedAssetKeys: ["newdirectory/directoryfile.txt"],
         patterns: [
@@ -221,7 +221,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move files to a new directory", (done) => {
+    it("should copy files to a new directory", (done) => {
       runEmit({
         expectedAssetKeys: [
           "newdirectory/.dottedfile",
@@ -240,7 +240,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move files to a new nested directory", (done) => {
+    it("should copy files to a new nested directory", (done) => {
       runEmit({
         expectedAssetKeys: [
           "newdirectory/deep-nested/deepnested.txt",
@@ -257,7 +257,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move files to a new directory out of context", (done) => {
+    it("should copy files to a new directory out of context", (done) => {
       runEmit({
         expectedAssetKeys: [
           "../tempdir/.dottedfile",
@@ -276,7 +276,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move files to a new directory when "to" is absolute path', (done) => {
+    it('should copy files to a new directory when "to" is absolute path', (done) => {
       runEmit({
         expectedAssetKeys: [
           ".dottedfile",
@@ -295,7 +295,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move files to a new directory when "to" is absolute path with a forward slash', (done) => {
+    it('should copy files to a new directory when "to" is absolute path with a forward slash', (done) => {
       runEmit({
         expectedAssetKeys: [
           ".dottedfile",
@@ -314,7 +314,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move files to a new directory from nested directory", (done) => {
+    it("should copy files to a new directory from nested directory", (done) => {
       runEmit({
         expectedAssetKeys: [
           "newdirectory/deep-nested/deepnested.txt",
@@ -331,7 +331,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file to a new directory when "to" is empty', (done) => {
+    it('should copy a file to a new directory when "to" is empty', (done) => {
       runEmit({
         expectedAssetKeys: ["file.txt"],
         patterns: [
@@ -347,7 +347,7 @@ describe("to option", () => {
   });
 
   describe("is a template", () => {
-    it('should move a file using "contenthash"', (done) => {
+    it('should copy a file using "contenthash"', (done) => {
       const compiler = getCompiler({
         output: {
           hashDigestLength: 6,
@@ -368,7 +368,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file using custom `contenthash` digest", (done) => {
+    it("should copy a file using custom `contenthash` digest", (done) => {
       const compiler = getCompiler({
         output: {
           hashFunction: "sha1",
@@ -391,7 +391,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file using `contenthash` with hashSalt", (done) => {
+    it("should copy a file using `contenthash` with hashSalt", (done) => {
       const compiler = getCompiler({
         output: {
           hashSalt: "qwerty",
@@ -412,7 +412,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file using "name" and "ext"', (done) => {
+    it('should copy a file using "name" and "ext"', (done) => {
       runEmit({
         expectedAssetKeys: ["binextension.bin"],
         patterns: [
@@ -426,7 +426,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file using "name", "contenthash" and "ext"', (done) => {
+    it('should copy a file using "name", "contenthash" and "ext"', (done) => {
       runEmit({
         expectedAssetKeys: ["file-5d7817.txt"],
         patterns: [
@@ -440,7 +440,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file from nested directory", (done) => {
+    it("should copy a file from nested directory", (done) => {
       runEmit({
         expectedAssetKeys: ["directoryfile-5d7817.txt"],
         patterns: [
@@ -454,7 +454,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move a file from nested directory to new directory", (done) => {
+    it("should copy a file from nested directory to new directory", (done) => {
       runEmit({
         expectedAssetKeys: ["newdirectory/directoryfile-5d7817.txt"],
         patterns: [
@@ -468,7 +468,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file without an extension using "name", "ext"', (done) => {
+    it('should copy a file without an extension using "name", "ext"', (done) => {
       runEmit({
         expectedAssetKeys: ["noextension.31d6cf.newext"],
         patterns: [
@@ -482,7 +482,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move files using "path", "name", "contenthash" and "ext"', (done) => {
+    it('should copy files using "path", "name", "contenthash" and "ext"', (done) => {
       runEmit({
         expectedAssetKeys: [
           "newdirectory/.dottedfile-5e294e",
@@ -501,7 +501,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it('should move a file to "compiler.options.output" by default', (done) => {
+    it('should copy a file to "compiler.options.output" by default', (done) => {
       runEmit({
         compilation: { output: { path: "/path/to" } },
         expectedAssetKeys: ["newfile.txt"],
@@ -718,7 +718,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move files", (done) => {
+    it("should copy files", (done) => {
       runEmit({
         expectedAssetKeys: ["txt"],
         patterns: [
@@ -739,7 +739,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move files to a non-root directory", (done) => {
+    it("should copy files to a non-root directory", (done) => {
       runEmit({
         expectedAssetKeys: ["nested/txt"],
         patterns: [
@@ -760,7 +760,7 @@ describe("to option", () => {
         .catch(done);
     });
 
-    it("should move files", (done) => {
+    it("should copy files", (done) => {
       runEmit({
         expectedAssetKeys: [
           "deep-nested-deepnested.txt",

--- a/test/to-option.test.js
+++ b/test/to-option.test.js
@@ -931,34 +931,51 @@ describe("to option", () => {
         .catch(done);
     });
   });
-});
 
-it("should rewrite invalid [contenthash] in 'production' mode", (done) => {
-  const compiler = getCompiler({
-    mode: "production",
-  });
-
-  runEmit({
-    compiler,
-    breakContenthash: {
-      // eslint-disable-next-line no-useless-escape
-      targetAssets: [
+  it("should process template string", (done) => {
+    runEmit({
+      expectedAssetKeys: [
+        "directory/directoryfile.txt-new-directoryfile.txt.5d7817ed5bc246756d73.ac7f6fcb65ddfcc43b2c-ac7f6fcb65ddfcc43b2c.txt--[unknown]",
+      ],
+      patterns: [
         {
-          name: "5d7817ed5bc246756d73-directoryfile.txt",
-          newName: "33333333333333333333-directoryfile.txt",
-          newHash: "33333333333333333333",
+          from: "directory/directoryfile.*",
+          to:
+            "[path][base]-new-[name][ext].[contenthash].[hash]-[fullhash][ext]--[unknown]",
         },
       ],
-    },
-    expectedAssetKeys: ["5d7817ed5bc246756d73-directoryfile.txt"],
-    patterns: [
-      {
-        from: "directory/directoryfile.*",
-        to: "[contenthash]-[name][ext]",
-        toType: "template",
+    })
+      .then(done)
+      .catch(done);
+  });
+
+  it("should rewrite invalid [contenthash] in 'production' mode", (done) => {
+    const compiler = getCompiler({
+      mode: "production",
+    });
+
+    runEmit({
+      compiler,
+      breakContenthash: {
+        // eslint-disable-next-line no-useless-escape
+        targetAssets: [
+          {
+            name: "5d7817ed5bc246756d73-directoryfile.txt",
+            newName: "33333333333333333333-directoryfile.txt",
+            newHash: "33333333333333333333",
+          },
+        ],
       },
-    ],
-  })
-    .then(done)
-    .catch(done);
+      expectedAssetKeys: ["5d7817ed5bc246756d73-directoryfile.txt"],
+      patterns: [
+        {
+          from: "directory/directoryfile.*",
+          to: "[contenthash]-[name][ext]",
+          toType: "template",
+        },
+      ],
+    })
+      .then(done)
+      .catch(done);
+  });
 });

--- a/test/to-option.test.js
+++ b/test/to-option.test.js
@@ -391,6 +391,27 @@ describe("to option", () => {
         .catch(done);
     });
 
+    it("should move a file using `contenthash` with hashSalt", (done) => {
+      const compiler = getCompiler({
+        output: {
+          hashSalt: "qwerty",
+        },
+      });
+
+      runEmit({
+        expectedAssetKeys: ["directory/64cc145fc382934bd97a.txt"],
+        patterns: [
+          {
+            from: "directory/directoryfile.txt",
+            to: "directory/[contenthash].txt",
+          },
+        ],
+        compiler,
+      })
+        .then(done)
+        .catch(done);
+    });
+
     it('should move a file using "name" and "ext"', (done) => {
       runEmit({
         expectedAssetKeys: ["binextension.bin"],

--- a/test/toType-option.test.js
+++ b/test/toType-option.test.js
@@ -40,13 +40,13 @@ describe("toType option", () => {
   it("should move a file to a new directory", (done) => {
     runEmit({
       expectedAssetKeys: [
-        "directory/directorynew-directoryfile.txt.5d7817ed5bc246756d73d6a4c8e94c33.5d7817ed5bc246756d73d6a4c8e94c33.22af645d.22af645d.txt",
+        "directory/directoryfile.txt-new-directoryfile.txt.5d7817ed5bc246756d73.ac7f6fcb65ddfcc43b2c-ac7f6fcb65ddfcc43b2c.txt",
       ],
       patterns: [
         {
           from: "directory/directoryfile.*",
           to:
-            "[path][folder]new-[name].[ext].[hash].[contenthash].[md5:contenthash:hex:8].[md5:hash:hex:8].txt",
+            "[path][base]-new-[name][ext].[contenthash].[hash]-[fullhash][ext]",
           toType: "template",
         },
       ],

--- a/test/toType-option.test.js
+++ b/test/toType-option.test.js
@@ -7,7 +7,7 @@ const FIXTURES_DIR_NORMALIZED = path
   .replace(/\\/g, "/");
 
 describe("toType option", () => {
-  it("should move a file to a new file", (done) => {
+  it("should copy a file to a new file", (done) => {
     runEmit({
       expectedAssetKeys: ["new-file.txt"],
       patterns: [
@@ -22,7 +22,7 @@ describe("toType option", () => {
       .catch(done);
   });
 
-  it("should move a file to a new directory", (done) => {
+  it("should copy a file to a new directory", (done) => {
     runEmit({
       expectedAssetKeys: ["new-file.txt/file.txt"],
       patterns: [
@@ -37,7 +37,7 @@ describe("toType option", () => {
       .catch(done);
   });
 
-  it("should move a file to a new directory", (done) => {
+  it("should copy a file to a new directory", (done) => {
     runEmit({
       expectedAssetKeys: [
         "directory/directoryfile.txt-new-directoryfile.txt.5d7817ed5bc246756d73.ac7f6fcb65ddfcc43b2c-ac7f6fcb65ddfcc43b2c.txt",
@@ -55,7 +55,7 @@ describe("toType option", () => {
       .catch(done);
   });
 
-  it("should move a file to a new file with no extension", (done) => {
+  it("should copy a file to a new file with no extension", (done) => {
     runEmit({
       expectedAssetKeys: ["newname"],
       patterns: [
@@ -70,7 +70,7 @@ describe("toType option", () => {
       .catch(done);
   });
 
-  it("should move a file to a new directory with an extension", (done) => {
+  it("should copy a file to a new directory with an extension", (done) => {
     runEmit({
       expectedAssetKeys: ["newdirectory.ext/file.txt"],
       patterns: [


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

- dropped `loader-utils` package
- [template strings in `to` option](https://github.com/webpack/loader-utils#interpolatename) removed in favor [webpack template strings](https://webpack.js.org/configuration/output/#template-strings)

### Breaking Changes

Yes

### Additional Info

Migration:
- `[hash]` and `[fullhash]` work as in webpack (i.e. it is hash of build, not hash of file)
- `.[ext]` => `[ext]`
- `[hash]` => `[contenthash]`
- [`<hashType>:contenthash:<digestType>:<length>`] => `[contenthash]` + [`output.hashdigest`](https://webpack.js.org/configuration/output/#outputhashdigest), [`output.hashDigestLength`](https://webpack.js.org/configuration/output/#outputhashdigestlength), [`output.hashFunction`](https://webpack.js.org/configuration/output/#outputhashfunction) options
- [N] - support was limited in #472 and removed in #565 in favor of using the `to` option as a function (#563)
- [folder] - not supported
- [emoji] - not supported


