### PR TITLE
Fix broken link to #globoptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ module.exports = {
 Type: `Function`
 Default: `undefined`
 
-> ℹ️ To ignore files by path please use the [`globOptions.ignore`]((#globoptions) option.
+> ℹ️ To ignore files by path please use the [`globOptions.ignore`](#globoptions) option.
 
 **webpack.config.js**
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I was browsing the `filter` documentation as seen [here](https://github.com/webpack-contrib/copy-webpack-plugin#filter) where I noticed that the internal link to `globOptions.ignore` is broken due to a typo.

You can review the fix on my forked repo: https://github.com/mhxbe/copy-webpack-plugin/tree/bugfix/fix-broken-link-globoptions#filter

### Breaking Changes

None.

### Additional Info
