### PR TITLE
fix: process-assets (#600)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",

--- a/src/index.js
+++ b/src/index.js
@@ -615,7 +615,7 @@ class CopyPlugin {
       compilation.hooks.processAssets.tapAsync(
         {
           name: "copy-webpack-plugin",
-          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
         },
         async (unusedAssets, callback) => {
           logger.log("starting to add additional assets...");


### PR DESCRIPTION
Updated "processAssets" hook to use the proper "PROCESS_ASSETS_STAGE_ADDITIONAL" stage instead of "PROCESS_ASSETS_STAGE_ADDITIONS" one.

This PR contains a:

- [X] **bugfix**

### Motivation / Use-Case

The `PROCESS_ASSETS_STAGE_ADDITIONAL` assets processing stage is much better suited for this plugin:

> `PROCESS_ASSETS_STAGE_ADDITIONAL` - Add additional assets to the compilation.

### Breaking Changes

I don't think that this could break any public contracts.

### Additional Info

Nope.