### PR TITLE
fix: add missing promise return types for transform, to and filter functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ const template = /\[\\*([\w:]+)\\*\]/i;
 /**
  * @callback ToFunction
  * @param {{ context: string, absoluteFilename?: string }} pathData
- * @return {string}
+ * @return {string | Promise<string>}
  */
 
 /**
@@ -74,7 +74,7 @@ const template = /\[\\*([\w:]+)\\*\]/i;
  * @callback TransformerFunction
  * @param {Buffer} input
  * @param {string} absoluteFilename
- * @returns {string | Buffer}
+ * @returns {string | Buffer | Promise<string> | Promise<Buffer>}
  */
 
 /**
@@ -94,13 +94,13 @@ const template = /\[\\*([\w:]+)\\*\]/i;
 /**
  * @callback Filter
  * @param {string} filepath
- * @returns {boolean}
+ * @returns {boolean | Promise<boolean>}
  */
 
 /**
  * @callback TransformAllFunction
  * @param {{ data: Buffer, sourceFilename: string, absoluteFilename: string }[]} data
- * @returns {string | Buffer}
+ * @returns {string | Buffer | Promise<string> | Promise<Buffer>}
  */
 
 /**
@@ -959,7 +959,7 @@ class CopyPlugin {
 
                     const filename =
                       typeof normalizedPattern.to === "function"
-                        ? normalizedPattern.to({ context })
+                        ? await normalizedPattern.to({ context })
                         : normalizedPattern.to;
 
                     if (template.test(filename)) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,7 +37,7 @@ export = CopyPlugin;
 /**
  * @callback ToFunction
  * @param {{ context: string, absoluteFilename?: string }} pathData
- * @return {string}
+ * @return {string | Promise<string>}
  */
 /**
  * @typedef {string | ToFunction} To
@@ -49,7 +49,7 @@ export = CopyPlugin;
  * @callback TransformerFunction
  * @param {Buffer} input
  * @param {string} absoluteFilename
- * @returns {string | Buffer}
+ * @returns {string | Buffer | Promise<string> | Promise<Buffer>}
  */
 /**
  * @typedef {{ keys: { [key: string]: any } } | { keys: ((defaultCacheKeys: { [key: string]: any }, absoluteFilename: string) => Promise<{ [key: string]: any }>) }} TransformerCacheObject
@@ -65,12 +65,12 @@ export = CopyPlugin;
 /**
  * @callback Filter
  * @param {string} filepath
- * @returns {boolean}
+ * @returns {boolean | Promise<boolean>}
  */
 /**
  * @callback TransformAllFunction
  * @param {{ data: Buffer, sourceFilename: string, absoluteFilename: string }[]} data
- * @returns {string | Buffer}
+ * @returns {string | Buffer | Promise<string> | Promise<Buffer>}
  */
 /**
  * @typedef { { [key: string]: string } | ((item: { absoluteFilename: string, sourceFilename: string, filename: string, toType: ToType }) => { [key: string]: string }) } Info
@@ -227,13 +227,13 @@ type From = string;
 type ToFunction = (pathData: {
   context: string;
   absoluteFilename?: string;
-}) => string;
+}) => string | Promise<string>;
 type To = string | ToFunction;
 type ToType = "dir" | "file" | "template";
 type TransformerFunction = (
   input: Buffer,
   absoluteFilename: string
-) => string | Buffer;
+) => string | Buffer | Promise<string> | Promise<Buffer>;
 type TransformerCacheObject =
   | {
       keys: {
@@ -255,14 +255,14 @@ type TransformerObject = {
   cache?: boolean | TransformerCacheObject | undefined;
 };
 type Transform = TransformerFunction | TransformerObject;
-type Filter = (filepath: string) => boolean;
+type Filter = (filepath: string) => boolean | Promise<boolean>;
 type TransformAllFunction = (
   data: {
     data: Buffer;
     sourceFilename: string;
     absoluteFilename: string;
   }[]
-) => string | Buffer;
+) => string | Buffer | Promise<string> | Promise<Buffer>;
 type Info =
   | {
       [key: string]: string;


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This PR fixes typing errors when trying to return a `Promise<string> | Promise<Buffer>` from `TransformerFunction`, and `TransformAllFunction`,  a `Promise<string>` from `ToFunction` and a `Promise<boolean>` from `Filter`.

All these functions should be possible to return a `Promise` as described in the `README.md`.

By adding the missing types I also found a bug, when using the `ToFunction` and trying to return a `Promise`.

### Breaking Changes

No breaking change.

### Additional Info
