### PR TITLE
chore: simplify glob usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,10 @@ The use of `context` is illustrated by these [`examples`](#examples).
 
 #### `globOptions`
 
+> [!WARNING]
+>
+> The *onlyDirectories* does not work because the plugin is designed to copy files.
+
 Type:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ The use of `context` is illustrated by these [`examples`](#examples).
 
 > [!WARNING]
 >
-> The *onlyDirectories* does not work because the plugin is designed to copy files.
+> The _onlyDirectories_ does not work because the plugin is designed to copy files.
 
 Type:
 

--- a/src/index.js
+++ b/src/index.js
@@ -340,9 +340,11 @@ class CopyPlugin {
 
     /** @type {GlobbyOptions & { objectMode: true }} */
     const globOptions = {
-      ...{ followSymbolicLinks: true },
+      followSymbolicLinks: true,
       ...(pattern.globOptions || {}),
-      ...{ cwd: pattern.context, objectMode: true },
+      cwd: pattern.context,
+      objectMode: true,
+      onlyFiles: true,
     };
 
     // @ts-ignore
@@ -412,7 +414,9 @@ class CopyPlugin {
     let globEntries;
 
     try {
-      globEntries = await globby(glob, globOptions);
+      globEntries = globOptions.onlyDirectories
+        ? []
+        : await globby(glob, globOptions);
     } catch (error) {
       compilation.errors.push(/** @type {WebpackError} */ (error));
 
@@ -448,11 +452,6 @@ class CopyPlugin {
            * @returns {Promise<CopiedResult | undefined>}
            */
           async (globEntry) => {
-            // Exclude directories
-            if (!globEntry.dirent.isFile()) {
-              return;
-            }
-
             if (pattern.filter) {
               let isFiltered;
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,6 @@ const getGlobby = memoize(async () => {
 /** @typedef {import("webpack").WebpackError} WebpackError */
 /** @typedef {import("webpack").Asset} Asset */
 /** @typedef {import("globby").Options} GlobbyOptions */
-/** @typedef {import("globby").GlobEntry} GlobEntry */
 /** @typedef {ReturnType<Compilation["getLogger"]>} WebpackLogger */
 /** @typedef {ReturnType<Compilation["getCache"]>} CacheFacade */
 /** @typedef {ReturnType<ReturnType<Compilation["getCache"]>["getLazyHashedEtag"]>} Etag */
@@ -338,12 +337,12 @@ class CopyPlugin {
       logger.debug(`determined '${absoluteFrom}' is a glob`);
     }
 
-    /** @type {GlobbyOptions & { objectMode: true }} */
+    /** @type {GlobbyOptions} */
     const globOptions = {
       followSymbolicLinks: true,
       ...(pattern.globOptions || {}),
       cwd: pattern.context,
-      objectMode: true,
+      objectMode: false,
       onlyFiles: true,
     };
 
@@ -409,7 +408,7 @@ class CopyPlugin {
     logger.log(`begin globbing '${glob}'...`);
 
     /**
-     * @type {GlobEntry[]}
+     * @type {string[]}
      */
     let globEntries;
 
@@ -448,7 +447,7 @@ class CopyPlugin {
       copiedResult = await Promise.all(
         globEntries.map(
           /**
-           * @param {GlobEntry} globEntry
+           * @param {string} globEntry
            * @returns {Promise<CopiedResult | undefined>}
            */
           async (globEntry) => {
@@ -456,7 +455,7 @@ class CopyPlugin {
               let isFiltered;
 
               try {
-                isFiltered = await pattern.filter(globEntry.path);
+                isFiltered = await pattern.filter(globEntry);
               } catch (error) {
                 compilation.errors.push(/** @type {WebpackError} */ (error));
 
@@ -464,13 +463,13 @@ class CopyPlugin {
               }
 
               if (!isFiltered) {
-                logger.log(`skip '${globEntry.path}', because it was filtered`);
+                logger.log(`skip '${globEntry}', because it was filtered`);
 
                 return;
               }
             }
 
-            const from = globEntry.path;
+            const from = globEntry;
 
             logger.debug(`found '${from}'`);
 

--- a/src/index.js
+++ b/src/index.js
@@ -413,9 +413,7 @@ class CopyPlugin {
     let globEntries;
 
     try {
-      globEntries = globOptions.onlyDirectories
-        ? []
-        : await globby(glob, globOptions);
+      globEntries = await globby(glob, globOptions);
     } catch (error) {
       compilation.errors.push(/** @type {WebpackError} */ (error));
 

--- a/test/globOptions-option.test.js
+++ b/test/globOptions-option.test.js
@@ -400,23 +400,6 @@ describe("globOptions option", () => {
       .catch(done);
   });
 
-  it('should work with the "onlyDirectories" option', (done) => {
-    runEmit({
-      expectedAssetKeys: [],
-      patterns: [
-        {
-          noErrorOnMissing: true,
-          from: "directory",
-          globOptions: {
-            onlyDirectories: true,
-          },
-        },
-      ],
-    })
-      .then(done)
-      .catch(done);
-  });
-
   it("should emit error when not found assets for copy", (done) => {
     expect.assertions(1);
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,6 @@ export = CopyPlugin;
 /** @typedef {import("webpack").WebpackError} WebpackError */
 /** @typedef {import("webpack").Asset} Asset */
 /** @typedef {import("globby").Options} GlobbyOptions */
-/** @typedef {import("globby").GlobEntry} GlobEntry */
 /** @typedef {ReturnType<Compilation["getLogger"]>} WebpackLogger */
 /** @typedef {ReturnType<Compilation["getCache"]>} CacheFacade */
 /** @typedef {ReturnType<ReturnType<Compilation["getCache"]>["getLazyHashedEtag"]>} Etag */
@@ -165,7 +164,6 @@ declare namespace CopyPlugin {
     WebpackError,
     Asset,
     GlobbyOptions,
-    GlobEntry,
     WebpackLogger,
     CacheFacade,
     Etag,
@@ -198,7 +196,6 @@ type Compilation = import("webpack").Compilation;
 type WebpackError = import("webpack").WebpackError;
 type Asset = import("webpack").Asset;
 type GlobbyOptions = import("globby").Options;
-type GlobEntry = import("globby").GlobEntry;
 type WebpackLogger = ReturnType<Compilation["getLogger"]>;
 type CacheFacade = ReturnType<Compilation["getCache"]>;
 type Etag = ReturnType<


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
I started looking at implementing https://github.com/webpack-contrib/copy-webpack-plugin/issues/788 and noticed that some of the glob usage here was more complicated than it needed to be.

The first thing that was being done with the glob results was to check if it's a file. However, globby has an `onlyFiles` option that we can use to avoid the need for that check. After that's done, there's no longer a need to set `objectMode`. Thus, instead of getting back an object, we can simply receive back a string, which is both simpler and better for performance.


### Breaking Changes

n/a
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

I may follow up with another PR to switch to `tinyglobby`. However, I thought it was better to separate those two refactorings to keep the PRs small and make it easier to debug if there are any unexpected issues