### PR TITLE
chore(deps): update serialize-javascript to ^7.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "glob-parent": "^6.0.1",
         "normalize-path": "^3.0.0",
         "schema-utils": "^4.2.0",
-        "serialize-javascript": "^7.0.3",
+        "serialize-javascript": "^7.0.5",
         "tinyglobby": "^0.2.12"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "glob-parent": "^6.0.1",
     "normalize-path": "^3.0.0",
     "schema-utils": "^4.2.0",
-    "serialize-javascript": "^7.0.3",
+    "serialize-javascript": "^7.0.5",
     "tinyglobby": "^0.2.12"
   },
   "devDependencies": {


### PR DESCRIPTION
**Summary**

Hi! I received a vulnerability report from serialize-javascript lesser than 7.0.5 [link](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) in which you can make a cpu ddos attack by having a very very long Array length.

I updated the base version of serialize-javascript so this doesn't happen 👍🏼 

**What kind of change does this PR introduce?**

dependency bugfix upgrade

**Did you add tests for your changes?**

not needed

**Does this PR introduce a breaking change?**

no

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

nope
